### PR TITLE
chore(seery/rules): add CLAUDE.md and path-scoped agent rules

### DIFF
--- a/.claude/rules/convex.md
+++ b/.claude/rules/convex.md
@@ -1,0 +1,37 @@
+---
+paths:
+  - "convex/**"
+---
+
+# Convex rules
+
+## Function shape
+
+- Named `export const` using `query`/`mutation`/`action`/`internalMutation` from `./_generated/server`, with `args` validators and an async `handler` that destructures args in its signature.
+- Validate every argument with `v.*`; hoist reused shapes to a module-level `const xArg = v.object({...})`.
+- Shared helpers live in `convex/utils/*.ts` as plain async functions taking `ctx`/`db` first. Shared constants/enums live in `convex/constants.ts` as `as const` objects — always import them, never redefine locally.
+- `export default` only for framework entrypoints (`schema.ts`, `http.ts`, `crons.ts`, `auth.config.ts`, `convex.config.ts`).
+
+## The guard ladder (every mutation, in this order, before any db write)
+
+1. **Auth**: `const identity = await ctx.auth.getUserIdentity(); if (!identity) throw new Error("Unauthenticated");` then `const uid = identity.subject;`
+2. **Membership/host**: `requireSessionMember(ctx, sessionId)` (throwing), plus an `isHost` check for host-only actions (start/advance/end/kick).
+3. **Rate limit**: `rateLimiter.limit(ctx, "<fnName>", { key: uid, throws: true })`, bucket registered in `convex/ratelimits.ts`.
+4. **State assert**: verify the state the mutation assumes (round is `open`, session is `LOBBY`, etc.).
+
+Skipping a step requires a code comment stating why.
+
+## Authz contract: everything throws
+
+Queries AND mutations throw on failed authz — never return `[]`/`null` to mask it. Thrown query errors surface through the root ErrorBoundary.
+
+**Single exception**: `getSession` is auth-only by design — session IDs are unguessable capability URLs and are the invite mechanism, so non-members must read the session to reach the join screen. Do not add a second exception; pre-reveal data (picks) stays guarded by round state.
+
+## Errors and queries
+
+- Fail with `throw new Error("<Sentence case message>")` immediately after the guard, one guard per line. Never return error objects.
+- Read through declared indexes: `.withIndex(...)` + `.unique()` for single docs. `.filter()` only narrows within an index, never as the sole selector.
+
+## Tests
+
+Every new or changed Convex function ships with `convex-test` coverage in the same PR, including negative authz cases (non-member, non-host, wrong state).

--- a/.claude/rules/react.md
+++ b/.claude/rules/react.md
@@ -1,0 +1,18 @@
+---
+paths:
+  - "src/**/*.{ts,tsx}"
+---
+
+# React rules
+
+- Components are named `export function PascalCase()` declarations in kebab-case files.
+- Props: a local `interface Props` directly above the component, destructured in the signature. Wrapper primitives extend the DOM attribute interface and spread `...rest`. Multi-file screens put shared props in a sibling `types.ts`.
+- Merge class names with `cn()` from `utils/cn` — never string concatenation or template literals.
+- Convex subscriptions live only in `src/db/use-*.ts` hooks: pass `"skip"` when an id is undefined and return `{ isLoading, <data> }`. Components never call `useQuery` directly.
+- A screen's data/effects aggregate in `screens/<name>/utils/use-<screen>-state.ts`. Render order: `if (isLoading) return <Loading />;` then `if (!x) return <DisplayError />;` before any other logic.
+- Thrown Convex query errors (failed authz) are handled by the root Sentry ErrorBoundary → `DisplayError` with a home link. Don't catch them per-screen.
+- Multi-file component/screen folders expose an `index.ts` barrel; import folders by their barrel path.
+- Conditional JSX uses an explicit ternary ending `: null` — no `&&` short-circuit rendering.
+- Every interactive element E2E drives has a `data-testid` (via a `testID?: string` prop or hardcoded).
+- Handlers: `on<Event>` for the action, `handle<Thing>` for wrappers, declared as `const fn = async () => {}` in the component body.
+- Prefer path aliases (`components/`, `screens/`, `db/`, `utils/`, …) over deep relative imports; relative only within the same folder. `import type` for types.

--- a/.claude/rules/routing.md
+++ b/.claude/rules/routing.md
@@ -1,0 +1,11 @@
+---
+paths:
+  - "src/routes/**"
+---
+
+# Routing rules
+
+- Route files: `export const Route = createFileRoute("<path>")({ component: XRoute })` with the component declared below; params via `Route.useParams()` cast to branded types (`as TOPIC_KEY`, `as SessionID`).
+- Route files stay thin: header chrome plus one screen component from `screens/*`. No business logic or data fetching in routes.
+- Navigate with the typed path pattern + `params` object (`navigate({ to: "/$topic/$year/$sessionId/$round", params, replace: true })`) — never interpolated strings, never raw `window.history`.
+- `src/routeTree.gen.ts` is generated — never edit it.

--- a/.claude/rules/styling.md
+++ b/.claude/rules/styling.md
@@ -1,0 +1,10 @@
+---
+paths:
+  - "src/**/*.{tsx,css}"
+---
+
+# Styling rules
+
+- Use only design tokens from `src/index.css` `@theme`: colors `black-100 / grey-100 / white-100 / white-200 / red-100 / blue-100 / green-100 / yellow-100`, spacing `sm|md|lg`, text `sm|md|lg|xl`, radii `sm|md|lg`. Never raw hex, arbitrary px values, or default Tailwind palette shades.
+- If a needed value has no token: add one to `@theme` following the existing naming scheme (`<color>-100` steps, `sm|md|lg` scales) and call it out in the PR description. Never inline the value instead.
+- Topic theming only through the `@utility` classes (`bg-topic`, `text-topic`, `border-topic`, `border-t-topic`, `bg-topic-light`), which resolve from `data-topic` set on the `/$topic` layout. Never hardcode a per-topic color.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,14 @@
+---
+paths:
+  - "playwright/**"
+  - "**/__tests__/**"
+  - "**/*.test.ts"
+---
+
+# Testing rules
+
+- Unit tests: `bun:test` (`import { describe, expect, it } from "bun:test"`) in a `__tests__/` folder beside the code, named `<subject>.test.ts`, with module-level `mock*` fixtures.
+- Convex functions are tested with `convex-test`, including negative authz cases (non-member, non-host, wrong state) for every guard.
+- E2E specs: `playwright/<area>/<name>.e2e.ts`, driving the app exclusively through `page.getByTestId(...)` with `await expect(...)` assertions between steps.
+- Seed/teardown server state through the `playwright/helpers/convex.ts` HTTP helpers — never through the UI.
+- Never weaken a failing test to make it pass (no loosened assertions, added retries, or skips). If the test looks wrong, say so in the PR instead.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Default owner for everything in the repo
 * @ryanseery
 
-# Agent forbidden zone — always require Ryan's review even if the default changes
+# Agent forbidden zone — always require human review even if the default changes
 /.github/ @ryanseery
 /.claude/ @ryanseery
 /CLAUDE.md @ryanseery

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,7 @@
 # Default owner for everything in the repo
 * @ryanseery
+
+# Agent forbidden zone — always require Ryan's review even if the default changes
+/.github/ @ryanseery
+/.claude/ @ryanseery
+/CLAUDE.md @ryanseery

--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,4 @@ yarn-error.*
 /android
 
 
-CLAUDE.md
-.claude/**
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ E2E: `bun run test:web` (Playwright, needs `.env.local`).
 
 ## Invariants
 
-- **Never modify without Ryan explicitly asking**: `.github/**`, `.claude/**`, `src/routeTree.gen.ts` (generated), or dependencies (`package.json` deps, `bun.lock`). Blocked work goes in the PR/ticket as a question instead.
+- **Never modify without a human dev explicitly asking**: `.github/**`, `.claude/**`, `src/routeTree.gen.ts` (generated), or dependencies (`package.json` deps, `bun.lock`). Blocked work goes in the PR/ticket as a question instead.
 - **Error handling in UI**: wrap every awaited Convex mutation/action call in `tryCatch` from `utils/try-catch`; on error, `Sentry.captureException(error)`, surface `error.message` via `useToast`, then early-return. Navigate/update state only on success. Never bare try/catch, never fire-and-forget mutations.
 - Import Sentry as a namespace (`import * as Sentry from "@sentry/react"`); it is initialized only in `services/sentry`.
 - Server-side authz **throws** — see `.claude/rules/convex.md` for the contract and the single exception.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,29 @@
+# what-of-the-year
+
+Yearly-picks party game. Vite + React 19 + TanStack Router (file-based) + Convex backend + Tailwind 4. Runtime and package manager: bun.
+
+Detailed rules live in `.claude/rules/` and load when you touch matching files.
+
+## Checks
+
+Run before pushing — CI enforces all four:
+
+```sh
+bun run check:format && bun run check:lint && bun run check:types && bun test
+```
+
+E2E: `bun run test:web` (Playwright, needs `.env.local`).
+
+## Invariants
+
+- **Never modify without Ryan explicitly asking**: `.github/**`, `.claude/**`, `src/routeTree.gen.ts` (generated), or dependencies (`package.json` deps, `bun.lock`). Blocked work goes in the PR/ticket as a question instead.
+- **Error handling in UI**: wrap every awaited Convex mutation/action call in `tryCatch` from `utils/try-catch`; on error, `Sentry.captureException(error)`, surface `error.message` via `useToast`, then early-return. Navigate/update state only on success. Never bare try/catch, never fire-and-forget mutations.
+- Import Sentry as a namespace (`import * as Sentry from "@sentry/react"`); it is initialized only in `services/sentry`.
+- Server-side authz **throws** — see `.claude/rules/convex.md` for the contract and the single exception.
+
+## Git
+
+- Conventional Commits: `type(scope): summary`, type ∈ `feat|fix|chore|ci`.
+- Human work: scope `seery/<topic>`, branches `seery/<topic>`.
+- Agent work: scope `agent/<topic>`, branches `agent/<issue#>-<slug>`.
+- PRs use the `## Summary` / `## Changes` template and merge to `main` via squash or rebase only.


### PR DESCRIPTION
## Summary

Rules for Claude ahead of the orchestration pipeline (Phase 3). Decisions from the 2026-08-26 rules grill-me. Mined from 29 candidate conventions; lint-enforced rules dropped.

## Changes

- `CLAUDE.md` — tiny always-loaded core: commands, error-handling invariant (tryCatch + Sentry + toast), agent forbidden zone (`.github/**`, `.claude/**`, `routeTree.gen.ts`, deps), git conventions incl. agent scope (`agent/<issue#>-<slug>` branches, `type(agent/<topic>)` commits)
- `.claude/rules/` — path-scoped, lazy-loaded: `convex.md` (guard ladder, everything-throws authz contract with the documented `getSession` capability-URL exception → closes rationale on #79, convex-test requirement), `react.md`, `routing.md`, `styling.md` (token-only + new-token process), `testing.md` (incl. never weaken a failing test)
- `.github/CODEOWNERS` — explicit `@ryanseery` on `/.github/`, `/.claude/`, `/CLAUDE.md` (partial #73)
- `.gitignore` — stop ignoring `CLAUDE.md`/`.claude/` (agents in CI need them); still ignores `.claude/settings.local.json`

Related: #95 (query-throw migration), #73, #77, #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)