### PR TITLE
ci(seery/deps): group security updates and github-actions bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,9 +16,17 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      security:
+        applies-to: security-updates
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Two gaps let Dependabot PRs arrive ungrouped: the `github-actions` ecosystem had no `groups:` block (separate PR per action bump, e.g. #62/#64), and security updates ignore version-update groups unless a group has `applies-to: security-updates` (e.g. #69 vite arriving solo).

## Changes

- `bun` ecosystem: add `security` group (`applies-to: security-updates`, all patterns)
- `github-actions` ecosystem: add `actions` group (all patterns)

Majors still PR individually (everything-else stays minor+patch by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)