### PR TITLE
ci(seery/e2e): hermetic e2e with local Convex backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,3 +154,4 @@ jobs:
             playwright-report/
             test-results/
           retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
           bunx convex deploy --yes
           bunx convex env set TEST_SECRET "${{ steps.creds.outputs.test_secret }}"
           bunx convex env set OPTIONS_FIXTURES 1
-          bunx convex env set JWT_PRIVATE_KEY "$(cat /tmp/jwt-private-key.txt)"
+          cat /tmp/jwt-private-key.txt | bunx convex env set JWT_PRIVATE_KEY
           bunx convex env set JWKS "$(cat /tmp/jwks.json)"
 
       - name: Build frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,13 +50,9 @@ jobs:
   e2e:
     needs: checks
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository
 
     permissions:
       contents: read
-
-    env:
-      CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
 
     steps:
       - name: Checkout code
@@ -91,38 +87,63 @@ jobs:
       - name: Install Playwright system dependencies
         run: bunx playwright install-deps chromium
 
-      - name: Deploy Convex preview and build
+      # Hermetic backend: a throwaway local Convex instance, ephemeral credentials,
+      # fixture option sources. No cloud, no repo secrets — runs identically for
+      # any actor (humans, Dependabot, forks).
+      - name: Start local Convex backend
         run: |
-          bunx convex deploy \
-            --preview-create "pr-${{ github.event.pull_request.number }}" \
-            --cmd 'echo "$VITE_CONVEX_URL" > /tmp/convex-cloud-url.txt && echo "$VITE_CONVEX_SITE_URL" > /tmp/convex-site-url.txt && bun run build' \
-            --cmd-url-env-var-name VITE_CONVEX_URL
+          INSTANCE_SECRET=$(openssl rand -hex 32)
+          echo "INSTANCE_SECRET=$INSTANCE_SECRET" >> "$GITHUB_ENV"
+          docker run -d --name convex-backend \
+            -p 3210:3210 -p 3211:3211 \
+            -e INSTANCE_NAME=woty-ci \
+            -e INSTANCE_SECRET="$INSTANCE_SECRET" \
+            -e CONVEX_CLOUD_ORIGIN=http://127.0.0.1:3210 \
+            -e CONVEX_SITE_ORIGIN=http://127.0.0.1:3211 \
+            -e DISABLE_BEACON=true \
+            ghcr.io/get-convex/convex-backend:latest
+          for i in $(seq 1 60); do
+            curl -fsS http://127.0.0.1:3210/version >/dev/null 2>&1 && exit 0
+            sleep 1
+          done
+          echo "Convex backend failed to become healthy" >&2
+          docker logs convex-backend >&2
+          exit 1
 
-      - name: Set environment variables on preview
-        env:
-          JWT_PRIVATE_KEY: ${{ secrets.JWT_PRIVATE_KEY }}
+      - name: Generate ephemeral credentials
+        id: creds
         run: |
-          bunx convex env set TEST_SECRET "${{ secrets.TEST_SECRET }}" \
-            --preview-name "pr-${{ github.event.pull_request.number }}"
-          echo "$JWT_PRIVATE_KEY" | bunx convex env set JWT_PRIVATE_KEY \
-            --preview-name "pr-${{ github.event.pull_request.number }}"
-          bunx convex env set JWKS '${{ secrets.JWKS }}' \
-            --preview-name "pr-${{ github.event.pull_request.number }}"
-          bunx convex env set IGDB_CLIENT_ID "${{ secrets.IGDB_CLIENT_ID }}" \
-            --preview-name "pr-${{ github.event.pull_request.number }}"
-          bunx convex env set IGDB_CLIENT_SECRET "${{ secrets.IGDB_CLIENT_SECRET }}" \
-            --preview-name "pr-${{ github.event.pull_request.number }}"
-          bunx convex env set TMDB_API_KEY "${{ secrets.TMDB_API_KEY }}" \
-            --preview-name "pr-${{ github.event.pull_request.number }}"
+          ADMIN_KEY=$(docker exec convex-backend ./generate_admin_key.sh | tail -1)
+          echo "::add-mask::$ADMIN_KEY"
+          echo "admin_key=$ADMIN_KEY" >> "$GITHUB_OUTPUT"
+          echo "test_secret=$(openssl rand -hex 32)" >> "$GITHUB_OUTPUT"
+          bun scripts/generate-test-keys.mjs
+
+      - name: Deploy functions and configure backend
+        env:
+          CONVEX_SELF_HOSTED_URL: http://127.0.0.1:3210
+          CONVEX_SELF_HOSTED_ADMIN_KEY: ${{ steps.creds.outputs.admin_key }}
+        run: |
+          bunx convex deploy --yes
+          bunx convex env set TEST_SECRET "${{ steps.creds.outputs.test_secret }}"
+          bunx convex env set OPTIONS_FIXTURES 1
+          bunx convex env set JWT_PRIVATE_KEY "$(cat /tmp/jwt-private-key.txt)"
+          bunx convex env set JWKS "$(cat /tmp/jwks.json)"
+
+      - name: Build frontend
+        run: VITE_CONVEX_URL=http://127.0.0.1:3210 bun run build
 
       - name: Run Playwright tests
         env:
-          TEST_SECRET: ${{ secrets.TEST_SECRET }}
+          TEST_SECRET: ${{ steps.creds.outputs.test_secret }}
+          CONVEX_SITE_URL: http://127.0.0.1:3211
           PLAYWRIGHT_FORCE_TTY: "120"
           FORCE_COLOR: "1"
-        run: |
-          CONVEX_SITE_URL=$(cat /tmp/convex-site-url.txt) \
-          bunx playwright test
+        run: bunx playwright test
+
+      - name: Dump backend logs on failure
+        if: failure()
+        run: docker logs convex-backend
 
       - name: Upload test artifacts
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
             -e CONVEX_CLOUD_ORIGIN=http://127.0.0.1:3210 \
             -e CONVEX_SITE_ORIGIN=http://127.0.0.1:3211 \
             -e DISABLE_BEACON=true \
-            ghcr.io/get-convex/convex-backend:latest
+            ghcr.io/get-convex/convex-backend@sha256:1f2044e3eac463ac78973b136c0baf72d4ada602611d853d6f99f280e29e0a98
           for i in $(seq 1 60); do
             curl -fsS http://127.0.0.1:3210/version >/dev/null 2>&1 && exit 0
             sleep 1

--- a/convex/igdb.ts
+++ b/convex/igdb.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 
 import { action } from "./_generated/server";
+import { fixtureGames } from "./test/fixtures";
 import { currentYear } from "./utils/dates";
 
 async function getAccessToken(): Promise<string> {
@@ -22,6 +23,8 @@ async function getAccessToken(): Promise<string> {
 export const getGames = action({
   args: { year: v.string() },
   handler: async (_, { year }) => {
+    if (process.env.OPTIONS_FIXTURES) return fixtureGames(year);
+
     const { startDate, endDate } = currentYear(year);
     const accessToken = await getAccessToken();
 

--- a/convex/openlibrary.ts
+++ b/convex/openlibrary.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 
 import { action } from "./_generated/server";
+import { fixtureBooks } from "./test/fixtures";
 
 interface OpenLibraryBook {
   key: string;
@@ -19,6 +20,8 @@ interface OpenLibraryResponse {
 export const getBooks = action({
   args: { year: v.string() },
   handler: async (_, { year }) => {
+    if (process.env.OPTIONS_FIXTURES) return fixtureBooks(year);
+
     const response = await fetch(
       `https://openlibrary.org/search.json?q=first_publish_year:${year}&sort=rating&limit=40&fields=key,title,first_publish_year,cover_i,ratings_average,description`,
       { headers: { "User-Agent": "WhatOfTheYear/1.0" } },

--- a/convex/test/fixtures.ts
+++ b/convex/test/fixtures.ts
@@ -1,0 +1,67 @@
+// Deterministic option fixtures served when OPTIONS_FIXTURES is set (hermetic CI).
+// Shapes mirror the raw third-party API responses each action normally returns,
+// so client transforms run unchanged. One title per letter a-z so any typed
+// letter surfaces a suggestion.
+const NAMES = [
+  "Alpha",
+  "Bravo",
+  "Charlie",
+  "Delta",
+  "Echo",
+  "Foxtrot",
+  "Golf",
+  "Hotel",
+  "India",
+  "Juliett",
+  "Kilo",
+  "Lima",
+  "Mike",
+  "November",
+  "Oscar",
+  "Papa",
+  "Quebec",
+  "Romeo",
+  "Sierra",
+  "Tango",
+  "Uniform",
+  "Victor",
+  "Whiskey",
+  "Xray",
+  "Yankee",
+  "Zulu",
+];
+
+export function fixtureMovies(year: string) {
+  return NAMES.map((name, i) => ({
+    id: i + 1,
+    title: `${name} Picture`,
+    poster_path: "",
+    vote_average: 7 + (i % 3),
+    release_date: `${year}-06-01`,
+    overview: `Fixture movie ${name}`,
+  }));
+}
+
+export function fixtureGames(year: string) {
+  const releaseDate = Math.floor(new Date(`${year}-06-01`).getTime() / 1000);
+  return NAMES.map((name, i) => ({
+    id: i + 1,
+    name: `${name} Quest`,
+    rating: 70 + (i % 20),
+    total_rating: 70 + (i % 20),
+    total_rating_count: 100,
+    first_release_date: releaseDate,
+    summary: `Fixture game ${name}`,
+  }));
+}
+
+export function fixtureBooks(year: string) {
+  return NAMES.map((name, i) => ({
+    key: `/works/OL${i + 1}W`,
+    title: `${name} Chronicles`,
+    first_publish_year: Number(year),
+    cover_i: i + 1,
+    ratings_average: 3.5 + (i % 3) * 0.5,
+    description: `Fixture book ${name}`,
+  }));
+}

--- a/convex/tmdb.ts
+++ b/convex/tmdb.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 
 import { action } from "./_generated/server";
+import { fixtureMovies } from "./test/fixtures";
 
 interface Movie {
   id: number;
@@ -20,6 +21,8 @@ interface TMDBResponse {
 export const getMovies = action({
   args: { year: v.string() },
   handler: async (_, { year }) => {
+    if (process.env.OPTIONS_FIXTURES) return fixtureMovies(year);
+
     const startDate = `${year}-01-01`;
     const endDate = `${year}-12-31`;
     const allMovies: Movie[] = [];

--- a/scripts/generate-test-keys.mjs
+++ b/scripts/generate-test-keys.mjs
@@ -1,0 +1,15 @@
+// Mints an ephemeral RS256 keypair for hermetic CI runs, in the same format
+// @convex-dev/auth expects (PKCS8 with spaces for JWT_PRIVATE_KEY, JWKS JSON).
+// Writes /tmp/jwt-private-key.txt and /tmp/jwks.json.
+import { writeFileSync } from "node:fs";
+
+import { exportJWK, exportPKCS8, generateKeyPair } from "jose";
+
+const { privateKey, publicKey } = await generateKeyPair("RS256", { extractable: true });
+const pkcs8 = (await exportPKCS8(privateKey)).trimEnd().replace(/\n/g, " ");
+const jwk = await exportJWK(publicKey);
+const jwks = JSON.stringify({ keys: [{ use: "sig", ...jwk }] });
+
+writeFileSync("/tmp/jwt-private-key.txt", pkcs8);
+writeFileSync("/tmp/jwks.json", jwks);
+console.log("wrote /tmp/jwt-private-key.txt and /tmp/jwks.json");

--- a/scripts/generate-test-keys.mjs
+++ b/scripts/generate-test-keys.mjs
@@ -12,4 +12,3 @@ const jwks = JSON.stringify({ keys: [{ use: "sig", ...jwk }] });
 
 writeFileSync("/tmp/jwt-private-key.txt", pkcs8);
 writeFileSync("/tmp/jwks.json", jwks);
-console.log("wrote /tmp/jwt-private-key.txt and /tmp/jwks.json");


### PR DESCRIPTION
## Summary

Closes #99. e2e no longer needs any repo secret: the job boots a throwaway local Convex backend, mints ephemeral credentials per run, and serves deterministic fixture options. CI now runs identically for humans, Dependabot, and forks — which unblocks the 5 open Dependabot PRs (#94) and deletes the fork-skip condition that was the #72 required-check bypass.

## Changes

- **ci.yml e2e job**: removed the `if: same-repo` guard and the job-level `CONVEX_DEPLOY_KEY`; replaced Convex preview deploy + secret injection with: `ghcr.io/get-convex/convex-backend` container (random instance secret, beacon disabled) → health-wait → admin key via `generate_admin_key.sh` (masked) → `convex deploy` self-hosted → env: random `TEST_SECRET`, ephemeral `JWT_PRIVATE_KEY`/`JWKS`, `OPTIONS_FIXTURES=1` → build against the local URL → Playwright against `127.0.0.1:3211`. Backend logs dump on failure.
- **convex/test/fixtures.ts**: raw-API-shaped fixture data (26 titles, one per letter, year-stamped) for movies/games/books
- **convex/{tmdb,igdb,openlibrary}.ts**: early-return fixtures when `OPTIONS_FIXTURES` is set — no TMDB/IGDB/Twitch/OpenLibrary calls in CI (chips at #84)
- **scripts/generate-test-keys.mjs**: ephemeral RS256 keypair in @convex-dev/auth format (PKCS8-with-spaces + JWKS)

## Notes

- This PR validates itself: the e2e run on it IS the hermetic path
- Preview deployments are gone from CI; if we want them back for manual poking on human PRs, that would be a separate non-required job
- `checks` job untouched

Related: #99, #94, #72, #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)