### PR TITLE
chore(seery/rules): require Closes #N in PR descriptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,3 +27,4 @@ E2E: `bun run test:web` (Playwright, needs `.env.local`).
 - Human work: scope `seery/<topic>`, branches `seery/<topic>`.
 - Agent work: scope `agent/<topic>`, branches `agent/<issue#>-<slug>`.
 - PRs use the `## Summary` / `## Changes` template and merge to `main` via squash or rebase only.
+- Every PR that resolves a ticket carries `Closes #<issue>` in its **description** (not just a commit message — squash/rebase merges make the body keyword the reliable auto-close path). One line per ticket if a PR resolves several.


### PR DESCRIPTION
## Summary

Codifies ticket auto-close: every PR resolving a ticket must carry `Closes #<issue>` in its description. Body keyword is the reliable path under squash/rebase merges (verified: #100 auto-closed #99 this way).

## Changes

- CLAUDE.md Git section: one rule line

🤖 Generated with [Claude Code](https://claude.com/claude-code)