### PR TITLE
feat(seery/pipeline): agent queue, reviewer, and resolve-loop workflows

### DIFF
--- a/.claude/skills/implement-ticket/SKILL.md
+++ b/.claude/skills/implement-ticket/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: implement-ticket
+description: Implement a GitHub issue end-to-end — branch, code, tests, PR. Used by the agent pipeline with the issue number as the argument.
+allowed-tools: Bash, Read, Edit, Write, Glob, Grep
+---
+
+# Implement ticket
+
+You are the pipeline's implement agent. The argument is a GitHub issue number in this repository. Work the ticket end-to-end and open a PR — or fail loudly. Never merge.
+
+## Procedure
+
+1. **Read the ticket**: `gh issue view <n> --comments`. Read `CLAUDE.md`; the path-scoped rules in `.claude/rules/` load as you touch matching files — follow all of them.
+2. **Scope check**: touch only what the ticket needs. If the ticket requires changing `.github/**`, `.claude/**`, `src/routeTree.gen.ts`, or dependencies (`package.json` deps, `bun.lock`), STOP — that is the forbidden zone. Follow the blocked protocol.
+3. **Branch**: `git switch -c agent/<n>-<short-slug>` off `main`.
+4. **Implement** per the rules. Any new or changed Convex function ships `convex-test` coverage in this PR, including negative authz cases.
+5. **Verify**: `bun run check:format && bun run check:lint && bun run check:types && bun test`. Fix what fails. Never weaken a failing test to make it pass — if a test looks wrong, say so in the PR instead.
+6. **Commit**: `type(agent/<topic>): summary` (Conventional Commits; type ∈ feat|fix|chore|ci).
+7. **Push and open the PR**: `gh pr create` using the repo PR template (`## Summary` / `## Changes`). The description MUST include `Closes #<n>` on its own line. Note anything the reviewer should look at first.
+
+## Blocked protocol
+
+If you cannot finish — forbidden zone required, requirements ambiguous enough that two readings mean different work, or a failure you cannot legitimately fix:
+
+- Do NOT open a PR or push a branch.
+- Comment on the issue: what you tried, exactly what blocked you, and what decision or change would unblock it.
+- Exit. The pipeline moves the ticket to the Blocked column.

--- a/.github/workflows/agent-queue.yml
+++ b/.github/workflows/agent-queue.yml
@@ -1,0 +1,97 @@
+name: Agent Queue
+
+on:
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: agent-pipeline
+  cancel-in-progress: false
+
+jobs:
+  next-ticket:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      issue: ${{ steps.pick.outputs.issue }}
+      item: ${{ steps.pick.outputs.item }}
+    steps:
+      - name: Pick oldest Ready ticket and move to In Progress
+        id: pick
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_PAT }}
+        run: |
+          FIELDS=$(gh api graphql -f query='query{organization(login:"30somethinggames"){projectV2(number:3){id field(name:"Status"){... on ProjectV2SingleSelectField{id options{id name}}}}}}')
+          PROJECT_ID=$(echo "$FIELDS" | jq -r '.data.organization.projectV2.id')
+          FIELD_ID=$(echo "$FIELDS" | jq -r '.data.organization.projectV2.field.id')
+          IN_PROGRESS=$(echo "$FIELDS" | jq -r '.data.organization.projectV2.field.options[] | select(.name=="In Progress") | .id')
+
+          ITEMS=$(gh api graphql -f query='query{organization(login:"30somethinggames"){projectV2(number:3){items(first:100){nodes{id createdAt fieldValueByName(name:"Status"){... on ProjectV2ItemFieldSingleSelectValue{name}} content{... on Issue{number state}}}}}}}')
+          PICK=$(echo "$ITEMS" | jq -r '[.data.organization.projectV2.items.nodes[] | select(.fieldValueByName.name=="Ready") | select(.content.state=="OPEN")] | sort_by(.createdAt) | first // empty | "\(.content.number) \(.id)"')
+
+          if [ -z "$PICK" ]; then
+            echo "Queue empty — nothing in Ready."
+            echo "issue=" >> "$GITHUB_OUTPUT"
+            echo "item=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          ISSUE=$(echo "$PICK" | cut -d' ' -f1)
+          ITEM=$(echo "$PICK" | cut -d' ' -f2)
+          gh api graphql -f query='mutation($p:ID!,$i:ID!,$f:ID!,$o:String!){updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{singleSelectOptionId:$o}}){projectV2Item{id}}}' \
+            -f p="$PROJECT_ID" -f i="$ITEM" -f f="$FIELD_ID" -f o="$IN_PROGRESS" >/dev/null
+          echo "Picked #$ISSUE"
+          echo "issue=$ISSUE" >> "$GITHUB_OUTPUT"
+          echo "item=$ITEM" >> "$GITHUB_OUTPUT"
+
+  implement:
+    needs: next-ticket
+    if: needs.next-ticket.outputs.issue != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: "/implement-ticket ${{ needs.next-ticket.outputs.issue }}"
+          claude_args: |
+            --model claude-sonnet-5
+            --max-turns 80
+
+  board-update:
+    needs: [next-ticket, implement]
+    if: always() && needs.next-ticket.outputs.issue != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Move to Blocked when no PR was opened
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_PAT }}
+          GH_REPO_TOKEN: ${{ github.token }}
+        run: |
+          ISSUE="${{ needs.next-ticket.outputs.issue }}"
+          ITEM="${{ needs.next-ticket.outputs.item }}"
+          HAS_PR=$(GH_TOKEN="$GH_REPO_TOKEN" gh pr list -R "${{ github.repository }}" --state open --json headRefName \
+            --jq "[.[] | select(.headRefName | startswith(\"agent/$ISSUE-\"))] | length")
+          if [ "$HAS_PR" -gt 0 ]; then
+            echo "PR exists for #$ISSUE — leaving In Progress."
+            exit 0
+          fi
+          echo "No PR for #$ISSUE — moving to Blocked."
+          FIELDS=$(gh api graphql -f query='query{organization(login:"30somethinggames"){projectV2(number:3){id field(name:"Status"){... on ProjectV2SingleSelectField{id options{id name}}}}}}')
+          PROJECT_ID=$(echo "$FIELDS" | jq -r '.data.organization.projectV2.id')
+          FIELD_ID=$(echo "$FIELDS" | jq -r '.data.organization.projectV2.field.id')
+          BLOCKED=$(echo "$FIELDS" | jq -r '.data.organization.projectV2.field.options[] | select(.name=="Blocked") | .id')
+          gh api graphql -f query='mutation($p:ID!,$i:ID!,$f:ID!,$o:String!){updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{singleSelectOptionId:$o}}){projectV2Item{id}}}' \
+            -f p="$PROJECT_ID" -f i="$ITEM" -f f="$FIELD_ID" -f o="$BLOCKED" >/dev/null

--- a/.github/workflows/agent-queue.yml
+++ b/.github/workflows/agent-queue.yml
@@ -28,17 +28,25 @@ jobs:
           IN_PROGRESS=$(echo "$FIELDS" | jq -r '.data.organization.projectV2.field.options[] | select(.name=="In Progress") | .id')
 
           ITEMS=$(gh api graphql -f query='query{organization(login:"30somethinggames"){projectV2(number:3){items(first:100){nodes{id createdAt fieldValueByName(name:"Status"){... on ProjectV2ItemFieldSingleSelectValue{name}} content{... on Issue{number state}}}}}}}')
-          PICK=$(echo "$ITEMS" | jq -r '[.data.organization.projectV2.items.nodes[] | select(.fieldValueByName.name=="Ready") | select(.content.state=="OPEN")] | sort_by(.createdAt) | first // empty | "\(.content.number) \(.id)"')
+          CANDIDATES=$(echo "$ITEMS" | jq -r '[.data.organization.projectV2.items.nodes[] | select(.fieldValueByName.name=="Ready") | select(.content.state=="OPEN")] | sort_by(.createdAt) | .[] | "\(.content.number) \(.id)"')
 
-          if [ -z "$PICK" ]; then
-            echo "Queue empty — nothing in Ready."
+          ISSUE=""; ITEM=""
+          while read -r num id; do
+            [ -z "$num" ] && continue
+            OPEN_BLOCKERS=$(gh api "repos/${{ github.repository }}/issues/$num/dependencies/blocked_by" --jq '[.[] | select(.state=="open")] | length' 2>/dev/null || echo 0)
+            if [ "$OPEN_BLOCKERS" -gt 0 ]; then
+              echo "Skipping #$num — $OPEN_BLOCKERS open blocker(s)."
+              continue
+            fi
+            ISSUE="$num"; ITEM="$id"; break
+          done <<< "$CANDIDATES"
+
+          if [ -z "$ISSUE" ]; then
+            echo "Queue empty — nothing unblocked in Ready."
             echo "issue=" >> "$GITHUB_OUTPUT"
             echo "item=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-
-          ISSUE=$(echo "$PICK" | cut -d' ' -f1)
-          ITEM=$(echo "$PICK" | cut -d' ' -f2)
           gh api graphql -f query='mutation($p:ID!,$i:ID!,$f:ID!,$o:String!){updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{singleSelectOptionId:$o}}){projectV2Item{id}}}' \
             -f p="$PROJECT_ID" -f i="$ITEM" -f f="$FIELD_ID" -f o="$IN_PROGRESS" >/dev/null
           echo "Picked #$ISSUE"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,34 @@
+name: Claude Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  review:
+    # One review per PR on open/ready. allowed_bots lets the reviewer run on
+    # agent-authored PRs; it can only post comments, and the interactive
+    # workflow still rejects bot actors, so no agent-on-agent loop is possible.
+    if: '!github.event.pull_request.draft'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "claude,claude[bot]"
+          plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
+          plugins: "code-review@claude-code-plugins"
+          prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+          claude_args: |
+            --model claude-sonnet-5
+            --allowedTools "mcp__github_inline_comment__create_inline_comment"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,33 @@
+name: Claude
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  claude:
+    # Interactive @claude — the resolve loop. Human actors only (default):
+    # Ryan comments "@claude fix the review comments" on a PR and the
+    # implementer picks the findings up on that branch.
+    if: contains(github.event.comment.body, '@claude')
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --model claude-sonnet-5
+            --max-turns 60


### PR DESCRIPTION
## Summary

Orchestration pipeline v1 (design: 2026-08-26 grill-me). Ready column = the queue; hourly poller starts a Sonnet 5 implement agent on the oldest Ready ticket; every PR gets an adversarial review; Ryan mediates the fix loop and remains the merge gate.

## Changes

- `.github/workflows/agent-queue.yml` — hourly cron + manual dispatch; `next-ticket` job (PROJECT_PAT) picks oldest Ready item, moves it In Progress; `implement` job runs claude-code-action (`/implement-ticket <n>`, Sonnet 5, max-turns 80, 45min timeout); `board-update` job moves the ticket to Blocked when no `agent/<n>-*` PR exists. Concurrency group = one agent at a time, queued.
- `.claude/skills/implement-ticket/SKILL.md` — versioned agent behavior: read ticket, forbidden-zone check, `agent/<n>-<slug>` branch, rules + convex-test requirement, full check suite, PR with `Closes #<n>`, blocked protocol (comment + no PR).
- `.github/workflows/claude-review.yml` — code-review plugin with `--comment` on every non-draft PR open/ready; `allowed_bots` admits agent-authored PRs (reviewer can only comment — the interactive workflow still rejects bots, so no loop).
- `.github/workflows/claude.yml` — interactive @claude for the resolve loop (human actors only).

## Requires (secrets, in flight)

`CLAUDE_CODE_OAUTH_TOKEN`, `PROJECT_PAT` (org project scope only) + Claude GitHub App installed.

## Battle-test after merge

Escalating ladder, one ticket to Ready at a time: #93 → #90 → #87 → #77-cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)