### PR TITLE
feat(seery/pipeline): PR template + review-pr skill replacing stock plugin

### DIFF
--- a/.claude/skills/implement-ticket/SKILL.md
+++ b/.claude/skills/implement-ticket/SKILL.md
@@ -16,7 +16,7 @@ You are the pipeline's implement agent. The argument is a GitHub issue number in
 4. **Implement** per the rules. Any new or changed Convex function ships `convex-test` coverage in this PR, including negative authz cases.
 5. **Verify**: `bun run check:format && bun run check:lint && bun run check:types && bun test`. Fix what fails. Never weaken a failing test to make it pass — if a test looks wrong, say so in the PR instead.
 6. **Commit**: `type(agent/<topic>): summary` (Conventional Commits; type ∈ feat|fix|chore|ci). The scope is a short descriptive TOPIC — e.g. `fix(agent/constants)`, `feat(agent/lobby)` — NEVER the issue number. Issue numbers belong only in the branch name and the `Closes #<n>` line. The PR title follows the same commit format.
-7. **Push and open the PR**: `gh pr create` using the repo PR template (`## Summary` / `## Changes`). The description MUST include `Closes #<n>` on its own line. Note anything the reviewer should look at first.
+7. **Push and open the PR**: `gh pr create` filling every section of `.github/pull_request_template.md`: `## Summary` (MUST include `Closes #<n>` on its own line), `## Changes`, `## Verification` (say exactly what you ran and what you could not verify — no checkbox theatre), `## Notes for reviewer` (what to look at first, tradeoffs, anything you were unsure about).
 
 ## Blocked protocol
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: review-pr
+description: Review a pull request against the repo rules, the ticket it closes, and a high-bar bug pass; post a verdict summary plus inline findings. Used by the review workflow with the PR number as the argument.
+allowed-tools: Bash, Read, Glob, Grep, Agent, mcp__github_inline_comment__create_inline_comment
+---
+
+# Review PR
+
+You are the pipeline's reviewer. The argument is a PR number in this repository. A human still reads every PR — your job is to make that read fast and to catch what the rules say must never merge. Never approve, request changes, or merge through GitHub review state; you only comment.
+
+## 0. Should this run?
+
+`gh pr view <n> --json state,isDraft,headRefName,body,title,comments`. Stop silently if the PR is closed or a draft.
+
+Find an existing summary comment (body starts with `<!-- review-pr -->`). If one exists this is a **re-run**: keep its comment id for editing, and `gh api repos/{owner}/{repo}/pulls/<n>/comments` to list existing inline comments so you never post a duplicate (same path + line + same rule/issue).
+
+## 1. Gather
+
+- **Ticket**: the `Closes #<t>` line in the PR body → `gh issue view <t> --comments`. If there is no `Closes` line, note it — that is a finding.
+- **Diff**: `gh pr diff <n>` and `gh pr diff <n> --name-only`.
+- **Rules**: read `CLAUDE.md`, then read every `.claude/rules/*.md` whose `paths:` frontmatter globs match at least one changed file. Every bullet in those files is a checklist item. Do not invent rules that are not written there.
+
+## 2. Ticket fit
+
+One or two sentences: does the diff do what the ticket asks? List anything the diff does that the ticket did not ask for, and anything the ticket asked for that is missing. If the ticket is ambiguous enough that you cannot tell, the verdict is **needs human**.
+
+## 3. Checklist
+
+For each rule bullet from step 1, decide **pass / fail / n/a** against the diff. A fail needs a `path:line` and a short quote of the rule. Checks that need context outside the diff (e.g. is the awaited mutation wrapped in `tryCatch` at its call site; does a `convex-test` file cover the changed function) — read the surrounding file, do not guess.
+
+Always check, regardless of paths:
+
+- Forbidden zone untouched: `.github/**`, `.claude/**`, `src/routeTree.gen.ts`, `package.json` dependencies, `bun.lock`.
+- `Closes #<t>` present and `<t>` matches the branch `agent/<t>-…` (agent PRs only).
+- All four PR template sections are filled; **Verification** says what was actually run, not just "checks pass".
+- No test was weakened: no loosened assertions, added retries, `.skip`, `.only`, or deleted cases.
+
+Do **not** comment on commit or PR title format — that is a CI check (#104), not a review finding.
+
+## 4. Bug pass
+
+Launch one **opus** subagent (`model: "opus"`) with the PR title, body, and full diff. Instructions for it:
+
+> Scan the diff for bugs. Diff only — do not read other files. Flag only issues you are certain of: code that will not compile or type-check, logic that is wrong regardless of input, security holes visible in the changed lines. Do not flag style, potential issues that depend on specific state, pre-existing code, or anything a linter catches. If you are not certain, do not flag it. Return a list of `{path, line, description}`.
+
+For **each** finding, launch a separate **opus** validator subagent with the PR title, body, the finding, and permission to read the repository. It must answer: is this definitely a real issue in this PR? Drop anything not confirmed.
+
+## 5. Verdict
+
+- **request changes** — any of: ticket fit fails; forbidden zone touched; a test was weakened; a confirmed bug; a fail on a `CLAUDE.md` invariant; a fail on the Convex guard ladder or authz contract; a new or changed Convex function without `convex-test` coverage including negative cases.
+- **needs human** — you cannot determine ticket fit; the PR's Verification section excuses a failed check and you cannot judge the excuse; anything else you are unsure how to weigh.
+- **approve** — everything else. Nits do not block.
+
+## 6. Post
+
+**Summary comment** — create with `gh pr comment <n> --body-file`, or on a re-run edit the existing one in place with `gh api -X PATCH repos/{owner}/{repo}/issues/comments/<id> -f body=@file`. Exact shape:
+
+```
+<!-- review-pr -->
+## Review — <approve | request changes | needs human>
+
+**Ticket fit:** <one or two sentences; out-of-scope items if any>
+
+### Blocking
+- <rule or bug> — `path:line` — <one line>
+
+### Should fix
+- …
+
+### Nits
+- …
+
+### Checklist
+CLAUDE.md ✅ 4/4 · convex.md ❌ 6/7 · react.md ✅ 3/3 · routing.md n/a · styling.md n/a · testing.md ✅ 2/2
+```
+
+Omit empty sections. Blocking = anything that drove **request changes**; Should fix = other rule fails; Nits = judgement calls that do not block.
+
+**Inline comments** — for every Blocking and Should fix item with a concrete `path:line`, post one comment with `mcp__github_inline_comment__create_inline_comment`. Include a committable suggestion block only when applying it fixes the issue entirely. On a re-run, skip any finding that already has an inline comment.
+
+## Do not
+
+- Post a GitHub review (`gh pr review`) in any state.
+- Flag things not written in `CLAUDE.md` or `.claude/rules/*.md` unless they came through the bug pass.
+- Pad the review. A clean PR gets `approve`, the ticket-fit line, and the checklist — nothing else.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,17 @@
- ## Summary
-  What this PR does and why.
+## Summary
 
-  ## Changes
-  - Key change 1
-  - Key change 2
+What this PR does and why.
+
+Closes #
+
+## Changes
+
+-
+
+## Verification
+
+How you verified it: which checks/tests you ran, what you exercised by hand, and what you could not verify and why.
+
+## Notes for reviewer
+
+What to look at first, tradeoffs, anything you weren't sure about.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -3,32 +3,40 @@ name: Claude Review
 on:
   pull_request:
     types: [opened, ready_for_review]
+  issue_comment:
+    types: [created]
 
 jobs:
   review:
-    # One review per PR on open/ready. allowed_bots lets the reviewer run on
-    # agent-authored PRs; it can only post comments, and the interactive
-    # workflow still rejects bot actors, so no agent-on-agent loop is possible.
-    if: '!github.event.pull_request.draft'
+    # One review per PR on open/ready, plus manual re-runs via an
+    # "@claude review" comment on the PR. allowed_bots lets the reviewer run
+    # on agent-authored PRs; it can only post comments, and the interactive
+    # workflow rejects bot actors and skips "@claude review", so no
+    # agent-on-agent loop is possible.
+    if: >-
+      (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude review'))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 1
+          # issue_comment fires on the default branch; check out the PR head
+          # so the reviewer reads the files under review.
+          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/head', github.event.issue.number) || '' }}
 
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "claude,claude[bot]"
-          plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
-          plugins: "code-review@claude-code-plugins"
-          prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+          prompt: "/review-pr ${{ github.event.pull_request.number || github.event.issue.number }}"
           claude_args: |
             --model claude-sonnet-5
-            --allowedTools "mcp__github_inline_comment__create_inline_comment"
+            --max-turns 60
+            --allowedTools "Bash(gh:*),Read,Glob,Grep,Agent,mcp__github_inline_comment__create_inline_comment"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,8 +10,9 @@ jobs:
   claude:
     # Interactive @claude — the resolve loop. Human actors only (default):
     # Ryan comments "@claude fix the review comments" on a PR and the
-    # implementer picks the findings up on that branch.
-    if: contains(github.event.comment.body, '@claude')
+    # implementer picks the findings up on that branch. "@claude review" is
+    # the reviewer's manual trigger (claude-review.yml), not ours.
+    if: contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude review')
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,5 +26,5 @@ E2E: `bun run test:web` (Playwright, needs `.env.local`).
 - Conventional Commits: `type(scope): summary`, type ∈ `feat|fix|chore|ci`.
 - Human work: scope `seery/<topic>`, branches `seery/<topic>`.
 - Agent work: scope `agent/<topic>`, branches `agent/<issue#>-<slug>`.
-- PRs use the `## Summary` / `## Changes` template and merge to `main` via squash or rebase only.
+- PRs fill every section of `.github/pull_request_template.md` (Summary / Changes / Verification / Notes for reviewer) and merge to `main` via squash or rebase only.
 - Every PR that resolves a ticket carries `Closes #<issue>` in its **description** (not just a commit message — squash/rebase merges make the body keyword the reliable auto-close path). One line per ticket if a PR resolves several.


### PR DESCRIPTION
## Summary

Two workflow enhancements before refining backlog tickets: a real PR template, and a repo-specific reviewer that enforces our written rules instead of the generic stock plugin.

No ticket.

## Changes

- `.github/pull_request_template.md`: was pasted twice and indented into a code block. Now Summary (with `Closes #`) / Changes / Verification (prose) / Notes for reviewer. `implement-ticket` step 7 and `CLAUDE.md` reference it.
- `.claude/skills/review-pr/SKILL.md`: reviewer reads `CLAUDE.md` + every `.claude/rules/*.md` matching changed paths and treats each bullet as a checklist item; checks ticket fit against the `Closes #` issue; opus finder → validator bug pass; posts `<!-- review-pr -->` summary with verdict (approve / request changes / needs human) + inline findings. Re-runs edit the summary and skip existing inline comments. Silent on title format (#104). Never sets GitHub review state.
- `.github/workflows/claude-review.yml`: drops `plugins`/`plugin_marketplaces`, runs `/review-pr <n>`; adds `issue_comment` trigger on `@claude review` with PR-head checkout.
- `.github/workflows/claude.yml`: excludes `@claude review` so the interactive loop and the reviewer never both fire.

## Verification

`bun run check:format` green. Workflow YAML not runnable locally — this PR is the first run of the new reviewer since `pull_request` uses the head branch's workflow file. Manual `@claude review` trigger untested until merged (needs `issue_comment` on default branch).

## Notes for reviewer

Watch the Claude Review check on this PR — it's reviewing its own definition. Things most likely to break: `--allowedTools` list (does `Agent` with `model: "opus"` work under claude-code-action), and `gh api -X PATCH` on re-run.
