### PR TITLE
chore(seery/testing): rule against tautological tests

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -12,3 +12,4 @@ paths:
 - E2E specs: `playwright/<area>/<name>.e2e.ts`, driving the app exclusively through `page.getByTestId(...)` with `await expect(...)` assertions between steps.
 - Seed/teardown server state through the `playwright/helpers/convex.ts` HTTP helpers — never through the UI.
 - Never weaken a failing test to make it pass (no loosened assertions, added retries, or skips). If the test looks wrong, say so in the PR instead.
+- No tautological tests — a test that cannot fail when the code is wrong because it restates the implementation. Expected values are literals or fixtures, never computed with the same expression the code under test uses; never assert a mock returns what it was told to return, compare a value to itself, snapshot without asserting content, or check only that a function was called when the ticket is about what it returns.

--- a/src/queries/__tests__/use-movies.test.ts
+++ b/src/queries/__tests__/use-movies.test.ts
@@ -44,7 +44,7 @@ describe("formMovieOptions", () => {
     expect(result.name).toBe("Test Movie");
     expect(result.cover).toBe("https://image.tmdb.org/t/p/w500/test.jpg");
     expect(result.rating).toBe(85);
-    expect(result.first_release_date).toBe(new Date("2024-01-15").getTime() / 1000);
+    expect(result.first_release_date).toBe(1705276800); // 2024-01-15T00:00:00Z
     expect(result.summary).toBe("Test summary");
   });
 


### PR DESCRIPTION
## Summary

Make "tautological tests considered harmful" a written rule so the reviewer enforces it, and fix the one existing near-instance.

Closes #106

## Changes

- `.claude/rules/testing.md`: new bullet defining a tautological test and the anti-patterns (expected value derived with the implementation's expression, asserting a mock returns its input, self-comparison, content-free snapshots, called-only assertions).
- `src/queries/__tests__/use-movies.test.ts:47`: expected `first_release_date` was `new Date("2024-01-15").getTime() / 1000` — same expression as the transform. Now the literal `1705276800`.

## Verification

`bun test` — 30 pass, 0 fail. `bun run check:format` clean. Audited all 7 unit test files; this was the only derived expected value.

## Notes for reviewer

Rule wording is the thing to look at — it's what `review-pr` will quote. Reviewer on this PR is still the stock plugin (the new one lands with #107).