### PR TITLE
ci(seery/pipeline): post-merge CI on main, bulleted review checklist

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -71,15 +71,8 @@ For **each** finding, launch a separate **opus** validator subagent with the PR 
 - …
 
 ### Checklist
-- CLAUDE.md ✅ 4/4
-- convex.md ❌ 6/7 — guard ladder: `startRound` skips rate limit without a comment
-- react.md ✅ 3/3
-- routing.md n/a
-- styling.md n/a
-- testing.md ✅ 2/2
+CLAUDE.md ✅ 4/4 · convex.md ❌ 6/7 · react.md ✅ 3/3 · routing.md n/a · styling.md n/a · testing.md ✅ 2/2
 ```
-
-One bullet per rules file, status and count first, then any note. Never join them on one line.
 
 Omit empty sections. Blocking = anything that drove **request changes**; Should fix = other rule fails; Nits = judgement calls that do not block.
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -71,8 +71,15 @@ For **each** finding, launch a separate **opus** validator subagent with the PR 
 - …
 
 ### Checklist
-CLAUDE.md ✅ 4/4 · convex.md ❌ 6/7 · react.md ✅ 3/3 · routing.md n/a · styling.md n/a · testing.md ✅ 2/2
+- CLAUDE.md ✅ 4/4
+- convex.md ❌ 6/7 — guard ladder: `startRound` skips rate limit without a comment
+- react.md ✅ 3/3
+- routing.md n/a
+- styling.md n/a
+- testing.md ✅ 2/2
 ```
+
+One bullet per rules file, status and count first, then any note. Never join them on one line.
 
 Omit empty sections. Blocking = anything that drove **request changes**; Should fix = other rule fails; Nits = judgement calls that do not block.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,14 @@ on:
   pull_request:
     branches:
       - main
+  # Post-merge safety net. The ruleset requires branches to be up to date
+  # before merge, so this only catches admin bypass pushes and flakes.
+  push:
+    branches:
+      - main
 
 concurrency:
-  group: ci-${{ github.event.pull_request.number }}
+  group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,8 @@ on:
 
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # Only PRs supersede themselves; a post-merge run on main must finish.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   checks:


### PR DESCRIPTION
## Summary

Follow-through on the merge-gate decisions: post-merge CI run on `main` as a safety net, and the reviewer's checklist rendered as a list instead of a joined line.

No ticket. Related: #109 (CI wall-clock), #86 (CI hygiene).

## Changes

- `.github/workflows/ci.yml`: add `push: branches: [main]` trigger; concurrency group falls back to `github.ref` when there is no PR number.
- `.claude/skills/review-pr/SKILL.md`: `### Checklist` is one bullet per rules file — status and count first, then any note.

Done outside this PR (ruleset, via API): `strict_required_status_checks_policy: true` and admin bypass narrowed from `always` to `pull_request`.

## Verification

`bun run check:format` clean. Workflow trigger can't be exercised until merged — the merge of this PR is its first push run. Checklist format is exercised by the Claude Review on this PR.

## Notes for reviewer

Check the review comment on this PR renders the checklist as bullets.