### PR TITLE
ci(seery/pipeline): agent queue comments on pick, flags crashed agents

### DIFF
--- a/.github/workflows/agent-queue.yml
+++ b/.github/workflows/agent-queue.yml
@@ -13,9 +13,12 @@ jobs:
   next-ticket:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      issues: write
     outputs:
       issue: ${{ steps.pick.outputs.issue }}
       item: ${{ steps.pick.outputs.item }}
+      started: ${{ steps.pick.outputs.started }}
     steps:
       - name: Pick oldest Ready ticket and move to In Progress
         id: pick
@@ -43,15 +46,23 @@ jobs:
 
           if [ -z "$ISSUE" ]; then
             echo "Queue empty — nothing unblocked in Ready."
+            echo "Queue empty — nothing unblocked in Ready." >> "$GITHUB_STEP_SUMMARY"
             echo "issue=" >> "$GITHUB_OUTPUT"
             echo "item=" >> "$GITHUB_OUTPUT"
+            echo "started=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           gh api graphql -f query='mutation($p:ID!,$i:ID!,$f:ID!,$o:String!){updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{singleSelectOptionId:$o}}){projectV2Item{id}}}' \
             -f p="$PROJECT_ID" -f i="$ITEM" -f f="$FIELD_ID" -f o="$IN_PROGRESS" >/dev/null
+          STARTED=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           echo "Picked #$ISSUE"
+          echo "Picked #$ISSUE — moved to In Progress." >> "$GITHUB_STEP_SUMMARY"
+          GH_TOKEN="${{ github.token }}" gh issue comment "$ISSUE" -R "${{ github.repository }}" \
+            --body "🤖 Picked up by the agent queue — [run]($RUN_URL)."
           echo "issue=$ISSUE" >> "$GITHUB_OUTPUT"
           echo "item=$ITEM" >> "$GITHUB_OUTPUT"
+          echo "started=$STARTED" >> "$GITHUB_OUTPUT"
 
   implement:
     needs: next-ticket
@@ -82,6 +93,9 @@ jobs:
     if: always() && needs.next-ticket.outputs.issue != ''
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      issues: write
+      pull-requests: read
     steps:
       - name: Move to Ready for Review (PR up) or Blocked (no PR)
         env:
@@ -90,14 +104,28 @@ jobs:
         run: |
           ISSUE="${{ needs.next-ticket.outputs.issue }}"
           ITEM="${{ needs.next-ticket.outputs.item }}"
+          STARTED="${{ needs.next-ticket.outputs.started }}"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           HAS_PR=$(GH_TOKEN="$GH_REPO_TOKEN" gh pr list -R "${{ github.repository }}" --state open --json headRefName \
             --jq "[.[] | select(.headRefName | startswith(\"agent/$ISSUE-\"))] | length")
           if [ "$HAS_PR" -gt 0 ]; then
             TARGET="Ready for Review"
           else
             TARGET="Blocked"
+            # Blocked protocol says the agent comments before exiting. No agent
+            # comment since pick time means it died (timeout, turn cap, error)
+            # rather than blocked deliberately — flag it so Ryan restarts
+            # instead of looking for a decision to make.
+            EXPLAINED=$(GH_TOKEN="$GH_REPO_TOKEN" gh api "repos/${{ github.repository }}/issues/$ISSUE/comments" \
+              --jq "[.[] | select((.user.login | startswith(\"claude\")) and .created_at > \"$STARTED\")] | length")
+            if [ "$EXPLAINED" -eq 0 ]; then
+              GH_TOKEN="$GH_REPO_TOKEN" gh issue edit "$ISSUE" -R "${{ github.repository }}" --add-label agent-failed
+              GH_TOKEN="$GH_REPO_TOKEN" gh issue comment "$ISSUE" -R "${{ github.repository }}" \
+                --body "⚠️ Blocked — the agent exited without a PR or an explanation (implement job: \`${{ needs.implement.result }}\`). See the [run]($RUN_URL). Remove \`agent-failed\` and move back to Ready to retry."
+            fi
           fi
           echo "#$ISSUE → $TARGET"
+          echo "#$ISSUE → $TARGET (implement job: ${{ needs.implement.result }})" >> "$GITHUB_STEP_SUMMARY"
           FIELDS=$(gh api graphql -f query='query{organization(login:"30somethinggames"){projectV2(number:3){id field(name:"Status"){... on ProjectV2SingleSelectField{id options{id name}}}}}}')
           PROJECT_ID=$(echo "$FIELDS" | jq -r '.data.organization.projectV2.id')
           FIELD_ID=$(echo "$FIELDS" | jq -r '.data.organization.projectV2.field.id')

--- a/.github/workflows/agent-queue.yml
+++ b/.github/workflows/agent-queue.yml
@@ -116,7 +116,7 @@ jobs:
             # comment since pick time means it died (timeout, turn cap, error)
             # rather than blocked deliberately — flag it so Ryan restarts
             # instead of looking for a decision to make.
-            EXPLAINED=$(GH_TOKEN="$GH_REPO_TOKEN" gh api "repos/${{ github.repository }}/issues/$ISSUE/comments" \
+            EXPLAINED=$(GH_TOKEN="$GH_REPO_TOKEN" gh api "repos/${{ github.repository }}/issues/$ISSUE/comments?per_page=100" \
               --jq "[.[] | select((.user.login | startswith(\"claude\")) and .created_at > \"$STARTED\")] | length")
             if [ "$EXPLAINED" -eq 0 ]; then
               GH_TOKEN="$GH_REPO_TOKEN" gh issue edit "$ISSUE" -R "${{ github.repository }}" --add-label agent-failed


### PR DESCRIPTION
## Summary

The board moved silently; now every agent-queue transition leaves a trace on the ticket, and a crashed agent is distinguishable from one that blocked on purpose.

No ticket.

## Changes

- `next-ticket`: comments `🤖 Picked up by the agent queue — run` on the issue; outputs `started` timestamp; step summary (`Picked #n` / `Queue empty`).
- `board-update`: on Blocked with no `claude*` comment since `started`, adds the new `agent-failed` label and comments with the run link + implement job result. Step summary either way.
- Both jobs get explicit `issues: write` permissions (they had none — `gh issue comment` with `github.token` would have failed).
- `agent-failed` label created out-of-band: "Agent exited without a PR or an explanation — needs a restart or a look at the run".

## Verification

`check:format` clean; YAML parses. Can't run the queue locally. Merged behaviour is exercised by the next scheduled run — #83 will be the first ticket through it. Edge to watch: `user.login | startswith("claude")` is the crash heuristic; if claude-code-action ever posts its own tracking comment on the issue it would read as "explained".

## Notes for reviewer

`board-update` uses two tokens: `PROJECT_PAT` for the board mutation, `github.token` for issue/PR reads and comments — same split as before, just more calls on the repo side.