### PR TITLE
ci(seery/pipeline): review every push, diff findings against prior run

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -12,7 +12,7 @@ You are the pipeline's reviewer. The argument is a PR number in this repository.
 
 `gh pr view <n> --json state,isDraft,headRefName,body,title,comments`. Stop silently if the PR is closed or a draft.
 
-Find an existing summary comment (body starts with `<!-- review-pr -->`). If one exists this is a **re-run**: keep its comment id for editing, and `gh api repos/{owner}/{repo}/pulls/<n>/comments` to list existing inline comments so you never post a duplicate (same path + line + same rule/issue).
+Find an existing summary comment (body starts with `<!-- review-pr -->`). If one exists this is a **re-run** — the reviewer runs on every push. Keep the comment id for editing, parse its Blocking / Should fix / Nits / Still open items as the **prior findings**, and `gh api repos/{owner}/{repo}/pulls/<n>/comments?per_page=100` to list existing inline comments (path, line, body). You will diff the new review against these in step 6, never restate them.
 
 ## 1. Gather
 
@@ -70,13 +70,29 @@ For **each** finding, launch a separate **opus** validator subagent with the PR 
 ### Nits
 - …
 
+### Still open
+- <finding raised in an earlier run, unchanged> — `path:line`
+
 ### Checklist
-CLAUDE.md ✅ 4/4 · convex.md ❌ 6/7 · react.md ✅ 3/3 · routing.md n/a · styling.md n/a · testing.md ✅ 2/2
+- CLAUDE.md ✅ 4/4
+- convex.md ❌ 6/7 — guard ladder: `startRound` skips rate limit without a comment
+- react.md ✅ 3/3
+- routing.md n/a
+- styling.md n/a
+- testing.md ✅ 2/2
 ```
 
-Omit empty sections. Blocking = anything that drove **request changes**; Should fix = other rule fails; Nits = judgement calls that do not block.
+Omit empty sections. Blocking = anything that drove **request changes**; Should fix = other rule fails; Nits = judgement calls that do not block. Checklist is one bullet per rules file, status and count first, then any note — never joined on one line.
 
-**Inline comments** — for every Blocking and Should fix item with a concrete `path:line`, post one comment with `mcp__github_inline_comment__create_inline_comment`. Include a committable suggestion block only when applying it fixes the issue entirely. On a re-run, skip any finding that already has an inline comment.
+**On a re-run**, every finding is one of three things — decide by comparing against the prior findings and the current diff, same issue = same rule or bug at the same place (line numbers may have shifted):
+
+- **Fixed** — the code no longer has it. Drop it entirely.
+- **Still open** — prior finding, code unchanged. Move it to `### Still open` as a one-liner; do not re-explain it, do not post a new inline comment.
+- **New** — not in the prior findings. Goes in Blocking / Should fix / Nits with a fresh inline comment.
+
+The verdict reflects the current state (fixed Blocking items no longer block). Edit the existing summary in place; never post a second summary.
+
+**Inline comments** — for every Blocking and Should fix item with a concrete `path:line`, post one comment with `mcp__github_inline_comment__create_inline_comment`. Include a committable suggestion block only when applying it fixes the issue entirely. Never post one for a Still open item — its original inline comment is still on the PR.
 
 ## Do not
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -12,7 +12,7 @@ You are the pipeline's reviewer. The argument is a PR number in this repository.
 
 `gh pr view <n> --json state,isDraft,headRefName,body,title,comments`. Stop silently if the PR is closed or a draft.
 
-Find an existing summary comment (body starts with `<!-- review-pr -->`). If one exists this is a **re-run** — the reviewer runs on every push. Keep the comment id for editing, parse its Blocking / Should fix / Nits / Still open items as the **prior findings**, and `gh api repos/{owner}/{repo}/pulls/<n>/comments?per_page=100` to list existing inline comments (path, line, body). You will diff the new review against these in step 6, never restate them.
+Look for earlier summary comments (body starts with `<!-- review-pr -->`). If any exist this is a **re-run** — the reviewer runs on every push. Collect the **prior findings**: every item in those summaries plus every inline comment from `gh api repos/{owner}/{repo}/pulls/<n>/comments?per_page=100` (path, line, body). In step 6 you report only what is new against this set; a finding already on the PR is never restated.
 
 ## 1. Gather
 
@@ -53,11 +53,11 @@ For **each** finding, launch a separate **opus** validator subagent with the PR 
 
 ## 6. Post
 
-**Summary comment** — create with `gh pr comment <n> --body-file`, or on a re-run edit the existing one in place with `gh api -X PATCH repos/{owner}/{repo}/issues/comments/<id> -f body=@file`. Exact shape:
+**Summary comment** — one new comment per run with `gh pr comment <n> --body-file`; never edit an earlier one, they are the history. Exact shape:
 
 ```
 <!-- review-pr -->
-## Review — <approve | request changes | needs human>
+## Review — <approve | request changes | needs human>[ (<k> open from earlier)]
 
 **Ticket fit:** <one or two sentences; out-of-scope items if any>
 
@@ -70,9 +70,6 @@ For **each** finding, launch a separate **opus** validator subagent with the PR 
 ### Nits
 - …
 
-### Still open
-- <finding raised in an earlier run, unchanged> — `path:line`
-
 ### Checklist
 - CLAUDE.md ✅ 4/4
 - convex.md ❌ 6/7 — guard ladder: `startRound` skips rate limit without a comment
@@ -84,15 +81,15 @@ For **each** finding, launch a separate **opus** validator subagent with the PR 
 
 Omit empty sections. Blocking = anything that drove **request changes**; Should fix = other rule fails; Nits = judgement calls that do not block. Checklist is one bullet per rules file, status and count first, then any note — never joined on one line.
 
-**On a re-run**, every finding is one of three things — decide by comparing against the prior findings and the current diff, same issue = same rule or bug at the same place (line numbers may have shifted):
+**On a re-run**, compare each finding against the prior findings — same issue = same rule or bug at the same place, line numbers may have shifted:
 
-- **Fixed** — the code no longer has it. Drop it entirely.
-- **Still open** — prior finding, code unchanged. Move it to `### Still open` as a one-liner; do not re-explain it, do not post a new inline comment.
-- **New** — not in the prior findings. Goes in Blocking / Should fix / Nits with a fresh inline comment.
+- **Already on the PR and still present** — not mentioned. Its inline thread is the record. It still counts toward the verdict; say so in the heading: `(2 open from earlier)`.
+- **Already on the PR and now fixed** — not mentioned. GitHub marks the inline thread outdated.
+- **New** — full entry in Blocking / Should fix / Nits plus an inline comment.
 
-The verdict reflects the current state (fixed Blocking items no longer block). Edit the existing summary in place; never post a second summary.
+The verdict always reflects the current state of the whole PR, not just this push. A re-run summary with a `request changes` verdict and no listed findings is correct when everything open was raised earlier.
 
-**Inline comments** — for every Blocking and Should fix item with a concrete `path:line`, post one comment with `mcp__github_inline_comment__create_inline_comment`. Include a committable suggestion block only when applying it fixes the issue entirely. Never post one for a Still open item — its original inline comment is still on the PR.
+**Inline comments** — for every new Blocking and Should fix item with a concrete `path:line`, post one comment with `mcp__github_inline_comment__create_inline_comment`. Include a committable suggestion block only when applying it fixes the issue entirely. Never post a second inline comment for an issue that already has one.
 
 ## Do not
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,17 +2,23 @@ name: Claude Review
 
 on:
   pull_request:
-    types: [opened, ready_for_review]
+    types: [opened, ready_for_review, synchronize]
   issue_comment:
     types: [created]
 
+# A new push supersedes an in-flight review of the same PR.
+concurrency:
+  group: review-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
   review:
-    # One review per PR on open/ready, plus manual re-runs via an
-    # "@claude review" comment on the PR. allowed_bots lets the reviewer run
-    # on agent-authored PRs; it can only post comments, and the interactive
-    # workflow rejects bot actors and skips "@claude review", so no
-    # agent-on-agent loop is possible.
+    # Reviews every push to a PR (the skill diffs against its own earlier
+    # findings, so re-runs update rather than repeat), plus manual re-runs via
+    # an "@claude review" comment. allowed_bots lets the reviewer run on
+    # agent-authored PRs and agent fix-pushes; it can only post comments, and
+    # the interactive workflow rejects bot actors and skips "@claude review",
+    # so no agent-on-agent loop is possible.
     if: >-
       (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude review'))


### PR DESCRIPTION
## Summary

The reviewer ran once per PR, so fix commits went unreviewed and the checks panel on the latest commit showed no review. Now it runs on every push, and each run reports only what is new.

No ticket.

## Changes

- `.github/workflows/claude-review.yml`: add `synchronize`; per-PR concurrency group with `cancel-in-progress` so a rapid second push supersedes the in-flight review.
- `.claude/skills/review-pr/SKILL.md`: one summary comment per run, never edited — earlier ones are the history. On re-run, findings already on the PR (fixed or not) are not restated; the inline thread is the record, and open ones are counted in the verdict heading (`request changes (2 open from earlier)`). New findings get a full entry + inline comment. Checklist rendered as one bullet per rules file (moved here from #110).

## Verification

`check:format` clean; YAML parses. Neither half can be observed on this PR: claude-code-action skips itself when the PR modifies its own workflow file, and restores `.claude/` from `origin/main`. First real test is the next PR after merge that gets a finding and a fix push.

## Notes for reviewer

"Same issue" matching on re-run is by rule/bug + location with tolerance for shifted line numbers — the judgement call most likely to misfire (a moved-but-unfixed finding showing as new). Watch the first few re-runs.