### PR TITLE
ci(seery/pipeline): drop agent-failed label, Blocked comment is the signal

### DIFF
--- a/.github/workflows/agent-queue.yml
+++ b/.github/workflows/agent-queue.yml
@@ -119,7 +119,6 @@ jobs:
             EXPLAINED=$(GH_TOKEN="$GH_REPO_TOKEN" gh api "repos/${{ github.repository }}/issues/$ISSUE/comments?per_page=100" \
               --jq "[.[] | select((.user.login | startswith(\"claude\")) and .created_at > \"$STARTED\")] | length")
             if [ "$EXPLAINED" -eq 0 ]; then
-              GH_TOKEN="$GH_REPO_TOKEN" gh issue edit "$ISSUE" -R "${{ github.repository }}" --add-label agent-failed
               GH_TOKEN="$GH_REPO_TOKEN" gh issue comment "$ISSUE" -R "${{ github.repository }}" \
                 --body "⚠️ Blocked — the agent exited without a PR or an explanation (implement job: \`${{ needs.implement.result }}\`). See the [run]($RUN_URL). Remove \`agent-failed\` and move back to Ready to retry."
             fi

--- a/.github/workflows/agent-queue.yml
+++ b/.github/workflows/agent-queue.yml
@@ -120,7 +120,7 @@ jobs:
               --jq "[.[] | select((.user.login | startswith(\"claude\")) and .created_at > \"$STARTED\")] | length")
             if [ "$EXPLAINED" -eq 0 ]; then
               GH_TOKEN="$GH_REPO_TOKEN" gh issue comment "$ISSUE" -R "${{ github.repository }}" \
-                --body "⚠️ Blocked — the agent exited without a PR or an explanation (implement job: \`${{ needs.implement.result }}\`). See the [run]($RUN_URL). Remove \`agent-failed\` and move back to Ready to retry."
+                --body "⚠️ Blocked — the agent exited without a PR or an explanation (implement job: \`${{ needs.implement.result }}\`). See the [run]($RUN_URL). Move back to Ready to retry."
             fi
           fi
           echo "#$ISSUE → $TARGET"


### PR DESCRIPTION
## Summary

Label pruning: process state lives in the board column and comments, not labels. The crashed-agent case is still detected and commented; it just no longer sets a label.

No ticket.

## Changes

- `.github/workflows/agent-queue.yml`: remove the `--add-label agent-failed` call; comment text no longer references the label. Label deleted from the repo.

## Verification

YAML parses. Behaviour exercised by the next Blocked-without-explanation run.

## Notes for reviewer

One-line removal.