### PR TITLE
chore(seery/pipeline): issue form with Summary/Change/Acceptance/Out of scope

### DIFF
--- a/.claude/skills/implement-ticket/SKILL.md
+++ b/.claude/skills/implement-ticket/SKILL.md
@@ -10,7 +10,7 @@ You are the pipeline's implement agent. The argument is a GitHub issue number in
 
 ## Procedure
 
-1. **Read the ticket**: `gh issue view <n> --comments`. Read `CLAUDE.md`; the path-scoped rules in `.claude/rules/` load as you touch matching files — follow all of them.
+1. **Read the ticket**: `gh issue view <n> --comments`. Tickets have **Summary / Change / Acceptance / Out of scope** sections — **Change** is what you build, **Acceptance** is what your PR must demonstrate, **Out of scope** is what you must not touch. Read `CLAUDE.md`; the path-scoped rules in `.claude/rules/` load as you touch matching files — follow all of them.
 2. **Scope check**: touch only what the ticket needs. If the ticket requires changing `.github/**`, `.claude/**`, `src/routeTree.gen.ts`, or dependencies (`package.json` deps, `bun.lock`), STOP — that is the forbidden zone. Follow the blocked protocol.
 3. **Branch**: `git switch -c agent/<n>-<short-slug>` off `main`.
 4. **Implement** per the rules. Any new or changed Convex function ships `convex-test` coverage in this PR, including negative authz cases.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -22,7 +22,7 @@ Look for earlier summary comments (body starts with `<!-- review-pr -->`). If an
 
 ## 2. Ticket fit
 
-One or two sentences: does the diff do what the ticket asks? List anything the diff does that the ticket did not ask for, and anything the ticket asked for that is missing. If the ticket is ambiguous enough that you cannot tell, the verdict is **needs human**.
+Tickets follow `.github/ISSUE_TEMPLATE/ticket.yml`: **Summary / Change / Acceptance / Out of scope**. Check the diff against **Change** (is everything listed there done, and nothing beyond it) and **Acceptance** (does each criterion hold — run or read what it takes to know). **Out of scope** items appearing in the diff are a finding. One or two sentences in the summary; list anything missing or extra. Older tickets without those sections: judge against the whole body. If the ticket is ambiguous enough that you cannot tell, the verdict is **needs human**.
 
 ## 3. Checklist
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/ticket.yml
+++ b/.github/ISSUE_TEMPLATE/ticket.yml
@@ -1,0 +1,29 @@
+name: Ticket
+description: Any piece of work — bug, feature, chore. Labels and milestone are set during refinement, not here.
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What and why, in a paragraph. Link the source (bug report, tweet, PR comment) if there is one.
+    validations:
+      required: true
+  - type: textarea
+    id: change
+    attributes:
+      label: Change
+      description: What is different when this is done. Concrete enough that a diff can be checked against it.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance
+      description: How we know it is done — behaviour to observe, checks that must pass, tests that must exist.
+    validations:
+      required: true
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of scope
+      description: Adjacent things this ticket deliberately does not touch.


### PR DESCRIPTION
## Summary

Tickets arrive free-form and get rewritten during refinement into something an agent can execute. An issue form does that at creation time and gives the reviewer a stable target for ticket fit.

No ticket.

## Changes

- `.github/ISSUE_TEMPLATE/ticket.yml`: one form — Summary, Change, Acceptance (all required), Out of scope (optional). No default labels or milestone; those are set in refinement.
- `.github/ISSUE_TEMPLATE/config.yml`: `blank_issues_enabled: false`.
- `.claude/skills/review-pr/SKILL.md`: ticket fit compares the diff against **Change** and **Acceptance**; **Out of scope** items in the diff are a finding; older tickets judged on the whole body.
- `.claude/skills/implement-ticket/SKILL.md`: step 1 names the sections and what each means for the agent.

## Verification

Both YAML files parse. Form renders on the next "New issue"; skill changes take effect after merge (`.claude/` is restored from main in CI).

## Notes for reviewer

Existing 21 open tickets keep their current bodies — the reviewer falls back to whole-body judgement for those.