### PR TITLE
ci(seery/pipeline): list failed and flaky e2e specs in the job summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,29 @@ jobs:
           FORCE_COLOR: "1"
         run: bunx playwright test
 
+      # Failed and flaky specs on the check's Details page, so nobody has to
+      # download the report to learn which test broke.
+      - name: Summarize e2e results
+        if: ${{ !cancelled() }}
+        run: |
+          F=test-results/results.json
+          if [ ! -f "$F" ]; then
+            echo "## e2e — no results file (run aborted before Playwright wrote one)" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          jq -r '
+            def strip: gsub("\u001b\\[[0-9;]*m"; "");
+            def specs(status): [.. | objects | select(has("specs")) | .specs[]
+              | select(any(.tests[]; .status == status))];
+            def firstError: [.tests[0].results[] | .error.message // empty] | first // "";
+            def render: .[] | "- **\(.title)** — `\(.file):\(.line)`"
+              + (firstError | strip | split("\n")[0]
+                 | if . == "" then "" else "\n  `" + . + "`" end);
+            (specs("unexpected") | if length > 0 then "## e2e failed (\(length))\n" + ([render] | join("\n")) + "\n" else empty end),
+            (specs("flaky") | if length > 0 then "## e2e flaky — passed on retry (\(length))\n" + ([render] | join("\n")) + "\n" else empty end),
+            (if (specs("unexpected") | length) == 0 and (specs("flaky") | length) == 0 then "## e2e — all passed, no retries" else empty end)
+          ' "$F" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Dump backend logs on failure
         if: failure()
         run: docker logs convex-backend

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,7 +7,9 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   workers: process.env.CI ? 4 : 1,
   retries: 1,
-  reporter: process.env.CI ? [["list"], ["github"]] : "list",
+  reporter: process.env.CI
+    ? [["list"], ["github"], ["json", { outputFile: "test-results/results.json" }]]
+    : "list",
   timeout: 30_000,
   expect: {
     timeout: 15_000,


### PR DESCRIPTION
## Summary

When e2e fails, the only artefact is a zipped Playwright report. This puts the failing spec names and first error line on the check's Details page, and lists flaky specs (passed on retry) on green runs too — `retries: 1` otherwise hides them.

No ticket. Related: #86 (retries mask flakes), #109 (CI wall-clock).

## Changes

- `playwright.config.ts`: CI reporter adds `json` → `test-results/results.json` (already in the uploaded artefact path).
- `.github/workflows/ci.yml`: `Summarize e2e results` step after the Playwright run, `if: !cancelled()`. jq over the JSON: `## e2e failed (n)` / `## e2e flaky — passed on retry (n)` with `title — file:line` + first error line (ANSI stripped), or `## e2e — all passed, no retries`. Handles the no-results-file case.

## Verification

jq program run locally against a fixture with one failed, one flaky, one passing spec and against an all-pass fixture — output as designed. YAML parses, `check:format` clean. This PR's own e2e run exercises the all-pass path; the failure path is exercised by the first red e2e.

## Notes for reviewer

Real Playwright JSON nests `suites[].suites[].specs[]`; the jq walks with `..` so depth doesn't matter. Error message is from the first attempt that has one, so flaky entries show why they failed before passing.