### PR TITLE
ci(seery/pipeline): run CI on merge_group for the merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
   push:
     branches:
       - main
+  # Merge queue: required checks run on the queue's temp branch before merge.
+  merge_group:
 
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary

Prerequisite for enabling the merge queue on `main`: required checks must report on the queue's temporary branch, which fires `merge_group`, not `pull_request`.

No ticket.

## Changes

- `.github/workflows/ci.yml`: add `merge_group:` trigger. Concurrency group falls through to `github.ref` for queue runs (already did for push).

## Verification

YAML parses. Nothing to observe until the queue is enabled in the ruleset — that happens after this merges, so queued PRs never wait on checks that can't run.

## Notes for reviewer

Merge this one the normal way; the queue rule goes on afterwards (squash, up to 5 entries built in parallel).