### PR TITLE
fix(seery/prod-gate): gate reset cron, test routes, and fixtures off prod

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,19 @@
    ```bash
    bun dev
    ```
+
+## Production deployment
+
+The prod deployment must never run the nightly reset cron, expose the `/test/*` seeding routes, or serve fixture options. All three are gated on `IS_PROD` (presence-only — any non-empty value, even `false`, counts as prod).
+
+Convex evaluates the cron and HTTP route gates at deploy time, so **set the flag before the first deploy** that includes this code:
+
+```bash
+bunx convex env set IS_PROD true --prod
+```
+
+Before every prod deploy, confirm no test switches are set:
+
+```bash
+bunx convex env list --prod   # must NOT list TEST_SECRET or OPTIONS_FIXTURES
+```

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -1,13 +1,17 @@
 import { cronJobs } from "convex/server";
 
 import { internal } from "./_generated/api";
+import { isProd } from "./utils/env";
 
 const crons = cronJobs();
 
-crons.daily(
-  "reset dev database",
-  { hourUTC: 7, minuteUTC: 0 }, // 2am Eastern (UTC-5)
-  internal.reset.clearAll,
-);
+// Dev/staging only: wipes every table. Evaluated at deploy time (see utils/env).
+if (!isProd()) {
+  crons.daily(
+    "reset dev database",
+    { hourUTC: 7, minuteUTC: 0 }, // 2am Eastern (UTC-5)
+    internal.reset.clearAll,
+  );
+}
 
 export default crons;

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -2,11 +2,12 @@ import { httpRouter } from "convex/server";
 
 import { auth } from "./auth";
 import { addPlayer, cleanup, makeSelection } from "./test/http";
+import { testRoutesEnabled } from "./utils/env";
 
 const http = httpRouter();
 auth.addHttpRoutes(http);
 
-if (process.env.TEST_SECRET) {
+if (testRoutesEnabled()) {
   http.route({ path: "/test/add-player", method: "POST", handler: addPlayer });
   http.route({ path: "/test/make-selection", method: "POST", handler: makeSelection });
   http.route({ path: "/test/cleanup", method: "POST", handler: cleanup });

--- a/convex/igdb.ts
+++ b/convex/igdb.ts
@@ -3,6 +3,7 @@ import { v } from "convex/values";
 import { action } from "./_generated/server";
 import { fixtureGames } from "./test/fixtures";
 import { currentYear } from "./utils/dates";
+import { useFixtures } from "./utils/env";
 
 async function getAccessToken(): Promise<string> {
   const response = await fetch("https://id.twitch.tv/oauth2/token", {
@@ -23,7 +24,7 @@ async function getAccessToken(): Promise<string> {
 export const getGames = action({
   args: { year: v.string() },
   handler: async (_, { year }) => {
-    if (process.env.OPTIONS_FIXTURES) return fixtureGames(year);
+    if (useFixtures()) return fixtureGames(year);
 
     const { startDate, endDate } = currentYear(year);
     const accessToken = await getAccessToken();

--- a/convex/openlibrary.ts
+++ b/convex/openlibrary.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 
 import { action } from "./_generated/server";
 import { fixtureBooks } from "./test/fixtures";
+import { useFixtures } from "./utils/env";
 
 interface OpenLibraryBook {
   key: string;
@@ -20,7 +21,7 @@ interface OpenLibraryResponse {
 export const getBooks = action({
   args: { year: v.string() },
   handler: async (_, { year }) => {
-    if (process.env.OPTIONS_FIXTURES) return fixtureBooks(year);
+    if (useFixtures()) return fixtureBooks(year);
 
     const response = await fetch(
       `https://openlibrary.org/search.json?q=first_publish_year:${year}&sort=rating&limit=40&fields=key,title,first_publish_year,cover_i,ratings_average,description`,

--- a/convex/reset.ts
+++ b/convex/reset.ts
@@ -1,7 +1,11 @@
 import { internalMutation } from "./_generated/server";
+import { isProd } from "./utils/env";
 
 export const clearAll = internalMutation({
   handler: async (ctx) => {
+    // Runtime guard, independent of cron registration: also blocks a manual dashboard run.
+    if (isProd()) throw new Error("Refusing to clear data on a prod deployment");
+
     const tables = [
       "sessions",
       "players",

--- a/convex/test/http.ts
+++ b/convex/test/http.ts
@@ -1,10 +1,13 @@
 import { internal } from "../_generated/api";
 import { httpAction } from "../_generated/server";
+import { timingSafeEqual } from "../utils/env";
 
 const UNAUTHORIZED = new Response("Unauthorized", { status: 401 });
 
 function guardTest(request: Request) {
-  if (request.headers.get("x-test-secret") !== process.env.TEST_SECRET) return UNAUTHORIZED;
+  const secret = process.env.TEST_SECRET;
+  const provided = request.headers.get("x-test-secret");
+  if (!secret || !provided || !timingSafeEqual(provided, secret)) return UNAUTHORIZED;
   return null;
 }
 

--- a/convex/tmdb.ts
+++ b/convex/tmdb.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 
 import { action } from "./_generated/server";
 import { fixtureMovies } from "./test/fixtures";
+import { useFixtures } from "./utils/env";
 
 interface Movie {
   id: number;
@@ -21,7 +22,7 @@ interface TMDBResponse {
 export const getMovies = action({
   args: { year: v.string() },
   handler: async (_, { year }) => {
-    if (process.env.OPTIONS_FIXTURES) return fixtureMovies(year);
+    if (useFixtures()) return fixtureMovies(year);
 
     const startDate = `${year}-01-01`;
     const endDate = `${year}-12-31`;

--- a/convex/utils/env.ts
+++ b/convex/utils/env.ts
@@ -1,0 +1,38 @@
+/**
+ * Deployment-level switches. Convex evaluates module-level `process.env` reads
+ * at deploy time only, so `IS_PROD` must be set on the prod deployment before
+ * the deploy that carries this code (see README "Production deployment").
+ */
+
+/** True on the prod deployment. Presence-only: any non-empty value counts. */
+export function isProd(): boolean {
+  return !!process.env.IS_PROD;
+}
+
+/** Serve deterministic option fixtures instead of calling third-party APIs. Never on prod. */
+export function useFixtures(): boolean {
+  return !!process.env.OPTIONS_FIXTURES && !isProd();
+}
+
+/** Expose the `/test/*` seeding routes. Never on prod. */
+export function testRoutesEnabled(): boolean {
+  return !!process.env.TEST_SECRET && !isProd();
+}
+
+/**
+ * Constant-time string comparison for secrets. Runs in the default Convex
+ * runtime (no `node:crypto`). Length mismatch short-circuits; the secret is
+ * fixed-length so that leaks nothing useful.
+ */
+export function timingSafeEqual(a: string, b: string): boolean {
+  const encoder = new TextEncoder();
+  const bytesA = encoder.encode(a);
+  const bytesB = encoder.encode(b);
+  if (bytesA.length !== bytesB.length) return false;
+
+  let diff = 0;
+  for (let i = 0; i < bytesA.length; i++) {
+    diff |= bytesA[i]! ^ bytesB[i]!;
+  }
+  return diff === 0;
+}

--- a/src/shared/__tests__/env.test.ts
+++ b/src/shared/__tests__/env.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import { isProd, testRoutesEnabled, timingSafeEqual, useFixtures } from "convex/utils/env";
+
+const KEYS = ["IS_PROD", "OPTIONS_FIXTURES", "TEST_SECRET"] as const;
+let saved: Record<string, string | undefined>;
+
+beforeEach(() => {
+  saved = Object.fromEntries(KEYS.map((k) => [k, process.env[k]]));
+  for (const k of KEYS) delete process.env[k];
+});
+
+afterEach(() => {
+  for (const k of KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+describe("isProd", () => {
+  it("is false when IS_PROD is unset or empty", () => {
+    expect(isProd()).toBe(false);
+    process.env.IS_PROD = "";
+    expect(isProd()).toBe(false);
+  });
+
+  it("is true for any non-empty value, including 'false'", () => {
+    process.env.IS_PROD = "true";
+    expect(isProd()).toBe(true);
+    process.env.IS_PROD = "1";
+    expect(isProd()).toBe(true);
+    process.env.IS_PROD = "false";
+    expect(isProd()).toBe(true);
+  });
+});
+
+describe("useFixtures", () => {
+  it("is false when OPTIONS_FIXTURES is unset", () => {
+    expect(useFixtures()).toBe(false);
+  });
+
+  it("is true when OPTIONS_FIXTURES is set off prod", () => {
+    process.env.OPTIONS_FIXTURES = "1";
+    expect(useFixtures()).toBe(true);
+  });
+
+  it("is false on prod even when OPTIONS_FIXTURES is set", () => {
+    process.env.OPTIONS_FIXTURES = "1";
+    process.env.IS_PROD = "true";
+    expect(useFixtures()).toBe(false);
+  });
+});
+
+describe("testRoutesEnabled", () => {
+  it("is false when TEST_SECRET is unset", () => {
+    expect(testRoutesEnabled()).toBe(false);
+  });
+
+  it("is true when TEST_SECRET is set off prod", () => {
+    process.env.TEST_SECRET = "abc";
+    expect(testRoutesEnabled()).toBe(true);
+  });
+
+  it("is false on prod even when TEST_SECRET is set", () => {
+    process.env.TEST_SECRET = "abc";
+    process.env.IS_PROD = "true";
+    expect(testRoutesEnabled()).toBe(false);
+  });
+});
+
+describe("timingSafeEqual", () => {
+  it("is true for identical strings", () => {
+    expect(timingSafeEqual("deadbeef", "deadbeef")).toBe(true);
+    expect(timingSafeEqual("", "")).toBe(true);
+  });
+
+  it("is false for same-length differing strings", () => {
+    expect(timingSafeEqual("deadbeef", "deadbeeg")).toBe(false);
+    expect(timingSafeEqual("aaaa", "aaab")).toBe(false);
+  });
+
+  it("is false for different-length strings", () => {
+    expect(timingSafeEqual("abc", "abcd")).toBe(false);
+    expect(timingSafeEqual("abc", "")).toBe(false);
+  });
+
+  it("compares non-ASCII strings by bytes", () => {
+    expect(timingSafeEqual("héllo", "héllo")).toBe(true);
+    expect(timingSafeEqual("héllo", "hello")).toBe(false);
+    expect(timingSafeEqual("é", "é")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Prod must never run the nightly `clearAll` reset cron, expose the `/test/*` seeding routes, or serve fixture options. All three were gated only on incidental env vars (`TEST_SECRET`, `OPTIONS_FIXTURES`) or not at all (the cron). This adds a single `IS_PROD` deployment switch and applies it at every site, plus a runtime guard inside `clearAll` itself, per the Convex docs/team guidance that env vars in cron and route definitions are only evaluated at deploy time.

Closes #71

## Changes

- `convex/utils/env.ts` (new): `isProd()` (presence-only), `useFixtures()`, `testRoutesEnabled()`, and a constant-time `timingSafeEqual` built on `TextEncoder` (default runtime — no `node:crypto`).
- `convex/crons.ts`: reset cron registered only when `!isProd()`.
- `convex/reset.ts`: `clearAll` throws on prod — runtime layer independent of registration, also blocks a manual dashboard run.
- `convex/http.ts`: `/test/*` routes registered only via `testRoutesEnabled()`.
- `convex/test/http.ts`: `guardTest` uses `timingSafeEqual`; missing header or unset secret → 401.
- `convex/{tmdb,igdb,openlibrary}.ts`: fixture early-return via `useFixtures()`.
- `README.md`: "Production deployment" section — set `IS_PROD` **before** the first deploy carrying this code; `env list --prod` must not show `TEST_SECRET`/`OPTIONS_FIXTURES`.
- `src/shared/__tests__/env.test.ts`: 12 `bun:test` cases covering every helper incl. prod-overrides and byte-wise compare.

## Verification

- `bun run check:format && bun run check:lint && bun run check:types && bun test` — all green locally (42 tests, 12 new).
- Not verified: an actual prod deploy with `IS_PROD` set. CI preview deploys never set `IS_PROD`, so e2e is unaffected and remains the check that the non-prod path still works.
- `convex-test` is not a dependency, so the registration branches in `crons.ts`/`http.ts` have no automated coverage; the gate logic is extracted into pure helpers so the unit tests cover the decisions.

## Notes for reviewer

- **Deploy ordering matters**: run `bunx convex env set IS_PROD true --prod` before merging/deploying. Setting it afterwards needs a redeploy for the static gates to take effect (the `clearAll` runtime throw applies immediately either way).
- Presence-only semantics: `IS_PROD=false` still counts as prod. Chosen as fail-closed for a destructive-cron gate; documented in the README.
- Tests live in `src/shared/__tests__/` rather than `convex/utils/__tests__/` (refinement said the latter) — matches where the existing `convex/utils/validate` tests already live.
- Typed `env` via `defineApp({ env })` exists in current Convex docs but not in installed `convex@1.45.0`, so this stays on `process.env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQ4Kr5SKxoTgXq5eKcWa15
