### PR TITLE
fix(seery/convex-error): throw ConvexError so messages survive prod redaction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,4 +27,5 @@ E2E: `bun run test:web` (Playwright, needs `.env.local`).
 - Human work: scope `seery/<topic>`, branches `seery/<topic>`.
 - Agent work: scope `agent/<topic>`, branches `agent/<issue#>-<slug>`.
 - PRs fill every section of `.github/pull_request_template.md` (Summary / Changes / Verification / Notes for reviewer) and merge to `main` via squash or rebase only.
+- Never add a `Claude-Session` trailer to commits or a session link to PR bodies.
 - Every PR that resolves a ticket carries `Closes #<issue>` in its **description** (not just a commit message — squash/rebase merges make the body keyword the reliable auto-close path). One line per ticket if a PR resolves several.

--- a/convex/igdb.ts
+++ b/convex/igdb.ts
@@ -16,6 +16,7 @@ async function getAccessToken(): Promise<string> {
     }),
   });
 
+  // internal: plain Error — nothing user-actionable; UI shows its generic load failure
   if (!response.ok) throw new Error(`Twitch OAuth error: ${response.status}`);
   const data = (await response.json()) as { access_token: string };
   return data.access_token;
@@ -45,6 +46,7 @@ export const getGames = action({
       `,
     });
 
+    // internal: plain Error — nothing user-actionable; UI shows its generic load failure
     if (!response.ok) throw new Error(`IGDB error: ${response.status}`);
     return response.json();
   },

--- a/convex/openlibrary.ts
+++ b/convex/openlibrary.ts
@@ -28,6 +28,7 @@ export const getBooks = action({
       { headers: { "User-Agent": "WhatOfTheYear/1.0" } },
     );
 
+    // internal: plain Error — nothing user-actionable; UI shows its generic load failure
     if (!response.ok) throw new Error(`Open Library error: ${response.status}`);
 
     const data: OpenLibraryResponse = await response.json();

--- a/convex/players.ts
+++ b/convex/players.ts
@@ -3,6 +3,7 @@ import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
 import { SessionStatus } from "./constants";
 import { rateLimiter } from "./ratelimits";
+import { appError } from "./utils/errors";
 import { getRoundByNumber } from "./utils/rounds";
 import { validateAvatar, validateName } from "./utils/validate";
 
@@ -14,27 +15,29 @@ export const joinSession = mutation({
   },
   handler: async (ctx, { sessionId, name, avatar }) => {
     const nameError = validateName(name);
-    if (nameError) throw new Error(nameError);
+    if (nameError) throw appError("VALIDATION", nameError);
     const avatarError = validateAvatar(avatar);
-    if (avatarError) throw new Error(avatarError);
+    if (avatarError) throw appError("VALIDATION", avatarError);
 
     const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw new Error("Unauthenticated");
+    if (!identity) throw appError("UNAUTHENTICATED", "Unauthenticated");
     const uid = identity.subject;
 
     await rateLimiter.limit(ctx, "joinSession", { key: uid, throws: true });
 
     const session = await ctx.db.get(sessionId);
-    if (!session) throw new Error("Session not found");
-    if (session.status !== SessionStatus.LOBBY) throw new Error("Session is closed");
-    if (session.playerCount >= session.maxPlayers) throw new Error("Session is full");
+    if (!session) throw appError("NOT_FOUND", "Session not found");
+    if (session.status !== SessionStatus.LOBBY)
+      throw appError("SESSION_CLOSED", "Session is closed");
+    if (session.playerCount >= session.maxPlayers)
+      throw appError("SESSION_FULL", "Session is full");
 
     // Check if already joined
     const existing = await ctx.db
       .query("players")
       .withIndex("by_session_uid", (q) => q.eq("sessionId", sessionId).eq("uid", uid))
       .unique();
-    if (existing) throw new Error("Already joined this session");
+    if (existing) throw appError("ALREADY_JOINED", "Already joined this session");
 
     await ctx.db.insert("players", {
       sessionId,
@@ -56,19 +59,19 @@ export const leaveSession = mutation({
   },
   handler: async (ctx, { sessionId }) => {
     const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw new Error("Unauthenticated");
+    if (!identity) throw appError("UNAUTHENTICATED", "Unauthenticated");
     const uid = identity.subject;
 
     const session = await ctx.db.get(sessionId);
-    if (!session) throw new Error("Session not found");
+    if (!session) throw appError("NOT_FOUND", "Session not found");
 
     const player = await ctx.db
       .query("players")
       .withIndex("by_session_uid", (q) => q.eq("sessionId", sessionId).eq("uid", uid))
       .unique();
 
-    if (!player) throw new Error("Player not in session");
-    if (player.isHost) throw new Error("Host cannot leave session");
+    if (!player) throw appError("NOT_MEMBER", "Player not in session");
+    if (player.isHost) throw appError("HOST_CANNOT_LEAVE", "Host cannot leave session");
 
     // Delete all selections by the leaving player
     const selections = await ctx.db
@@ -120,25 +123,25 @@ export const kickFromLobby = mutation({
   },
   handler: async (ctx, { sessionId, uid }) => {
     const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw new Error("Unauthenticated");
+    if (!identity) throw appError("UNAUTHENTICATED", "Unauthenticated");
 
     const host = await ctx.db
       .query("players")
       .withIndex("by_session_uid", (q) => q.eq("sessionId", sessionId).eq("uid", identity.subject))
       .unique();
-    if (!host?.isHost) throw new Error("Only the host can kick players");
+    if (!host?.isHost) throw appError("NOT_HOST", "Only the host can kick players");
 
     const player = await ctx.db
       .query("players")
       .withIndex("by_session_uid", (q) => q.eq("sessionId", sessionId).eq("uid", uid))
       .unique();
-    if (!player) throw new Error("Player not found");
-    if (player.isHost) throw new Error("Cannot kick the host");
+    if (!player) throw appError("NOT_FOUND", "Player not found");
+    if (player.isHost) throw appError("CANNOT_KICK_HOST", "Cannot kick the host");
 
     const session = await ctx.db.get(sessionId);
-    if (!session) throw new Error("Session not found");
+    if (!session) throw appError("NOT_FOUND", "Session not found");
     if (session.status !== SessionStatus.LOBBY)
-      throw new Error("Cannot kick from lobby after game has started");
+      throw appError("WRONG_STATE", "Cannot kick from lobby after game has started");
 
     await ctx.db.delete(player._id);
     await ctx.db.patch(sessionId, {
@@ -154,23 +157,23 @@ export const kickFromGame = mutation({
   },
   handler: async (ctx, { sessionId, uid }) => {
     const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw new Error("Unauthenticated");
+    if (!identity) throw appError("UNAUTHENTICATED", "Unauthenticated");
 
     const host = await ctx.db
       .query("players")
       .withIndex("by_session_uid", (q) => q.eq("sessionId", sessionId).eq("uid", identity.subject))
       .unique();
-    if (!host?.isHost) throw new Error("Only the host can kick players");
+    if (!host?.isHost) throw appError("NOT_HOST", "Only the host can kick players");
 
     const player = await ctx.db
       .query("players")
       .withIndex("by_session_uid", (q) => q.eq("sessionId", sessionId).eq("uid", uid))
       .unique();
-    if (!player) throw new Error("Player not found");
-    if (player.isHost) throw new Error("Cannot kick the host");
+    if (!player) throw appError("NOT_FOUND", "Player not found");
+    if (player.isHost) throw appError("CANNOT_KICK_HOST", "Cannot kick the host");
 
     const session = await ctx.db.get(sessionId);
-    if (!session) throw new Error("Session not found");
+    if (!session) throw appError("NOT_FOUND", "Session not found");
 
     // Delete all selections by the kicked player
     const selections = await ctx.db
@@ -219,7 +222,7 @@ export const getPlayers = query({
   args: { sessionId: v.id("sessions") },
   handler: async (ctx, { sessionId }) => {
     const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw new Error("Unauthenticated");
+    if (!identity) throw appError("UNAUTHENTICATED", "Unauthenticated");
 
     return await ctx.db
       .query("players")

--- a/convex/players.ts
+++ b/convex/players.ts
@@ -3,7 +3,7 @@ import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
 import { SessionStatus } from "./constants";
 import { rateLimiter } from "./ratelimits";
-import { appError } from "./utils/errors";
+import { apiError } from "./utils/errors";
 import { getRoundByNumber } from "./utils/rounds";
 import { validateAvatar, validateName } from "./utils/validate";
 
@@ -15,29 +15,29 @@ export const joinSession = mutation({
   },
   handler: async (ctx, { sessionId, name, avatar }) => {
     const nameError = validateName(name);
-    if (nameError) throw appError("VALIDATION", nameError);
+    if (nameError) throw apiError("VALIDATION", nameError);
     const avatarError = validateAvatar(avatar);
-    if (avatarError) throw appError("VALIDATION", avatarError);
+    if (avatarError) throw apiError("VALIDATION", avatarError);
 
     const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw appError("UNAUTHENTICATED", "Unauthenticated");
+    if (!identity) throw apiError("UNAUTHENTICATED", "Unauthenticated");
     const uid = identity.subject;
 
     await rateLimiter.limit(ctx, "joinSession", { key: uid, throws: true });
 
     const session = await ctx.db.get(sessionId);
-    if (!session) throw appError("NOT_FOUND", "Session not found");
+    if (!session) throw apiError("NOT_FOUND", "Session not found");
     if (session.status !== SessionStatus.LOBBY)
-      throw appError("SESSION_CLOSED", "Session is closed");
+      throw apiError("SESSION_CLOSED", "Session is closed");
     if (session.playerCount >= session.maxPlayers)
-      throw appError("SESSION_FULL", "Session is full");
+      throw apiError("SESSION_FULL", "Session is full");
 
     // Check if already joined
     const existing = await ctx.db
       .query("players")
       .withIndex("by_session_uid", (q) => q.eq("sessionId", sessionId).eq("uid", uid))
       .unique();
-    if (existing) throw appError("ALREADY_JOINED", "Already joined this session");
+    if (existing) throw apiError("ALREADY_JOINED", "Already joined this session");
 
     await ctx.db.insert("players", {
       sessionId,
@@ -59,19 +59,19 @@ export const leaveSession = mutation({
   },
   handler: async (ctx, { sessionId }) => {
     const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw appError("UNAUTHENTICATED", "Unauthenticated");
+    if (!identity) throw apiError("UNAUTHENTICATED", "Unauthenticated");
     const uid = identity.subject;
 
     const session = await ctx.db.get(sessionId);
-    if (!session) throw appError("NOT_FOUND", "Session not found");
+    if (!session) throw apiError("NOT_FOUND", "Session not found");
 
     const player = await ctx.db
       .query("players")
       .withIndex("by_session_uid", (q) => q.eq("sessionId", sessionId).eq("uid", uid))
       .unique();
 
-    if (!player) throw appError("NOT_MEMBER", "Player not in session");
-    if (player.isHost) throw appError("HOST_CANNOT_LEAVE", "Host cannot leave session");
+    if (!player) throw apiError("NOT_MEMBER", "Player not in session");
+    if (player.isHost) throw apiError("HOST_CANNOT_LEAVE", "Host cannot leave session");
 
     // Delete all selections by the leaving player
     const selections = await ctx.db
@@ -123,25 +123,25 @@ export const kickFromLobby = mutation({
   },
   handler: async (ctx, { sessionId, uid }) => {
     const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw appError("UNAUTHENTICATED", "Unauthenticated");
+    if (!identity) throw apiError("UNAUTHENTICATED", "Unauthenticated");
 
     const host = await ctx.db
       .query("players")
       .withIndex("by_session_uid", (q) => q.eq("sessionId", sessionId).eq("uid", identity.subject))
       .unique();
-    if (!host?.isHost) throw appError("NOT_HOST", "Only the host can kick players");
+    if (!host?.isHost) throw apiError("NOT_HOST", "Only the host can kick players");
 
     const player = await ctx.db
       .query("players")
       .withIndex("by_session_uid", (q) => q.eq("sessionId", sessionId).eq("uid", uid))
       .unique();
-    if (!player) throw appError("NOT_FOUND", "Player not found");
-    if (player.isHost) throw appError("CANNOT_KICK_HOST", "Cannot kick the host");
+    if (!player) throw apiError("NOT_FOUND", "Player not found");
+    if (player.isHost) throw apiError("CANNOT_KICK_HOST", "Cannot kick the host");
 
     const session = await ctx.db.get(sessionId);
-    if (!session) throw appError("NOT_FOUND", "Session not found");
+    if (!session) throw apiError("NOT_FOUND", "Session not found");
     if (session.status !== SessionStatus.LOBBY)
-      throw appError("WRONG_STATE", "Cannot kick from lobby after game has started");
+      throw apiError("WRONG_STATE", "Cannot kick from lobby after game has started");
 
     await ctx.db.delete(player._id);
     await ctx.db.patch(sessionId, {
@@ -157,23 +157,23 @@ export const kickFromGame = mutation({
   },
   handler: async (ctx, { sessionId, uid }) => {
     const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw appError("UNAUTHENTICATED", "Unauthenticated");
+    if (!identity) throw apiError("UNAUTHENTICATED", "Unauthenticated");
 
     const host = await ctx.db
       .query("players")
       .withIndex("by_session_uid", (q) => q.eq("sessionId", sessionId).eq("uid", identity.subject))
       .unique();
-    if (!host?.isHost) throw appError("NOT_HOST", "Only the host can kick players");
+    if (!host?.isHost) throw apiError("NOT_HOST", "Only the host can kick players");
 
     const player = await ctx.db
       .query("players")
       .withIndex("by_session_uid", (q) => q.eq("sessionId", sessionId).eq("uid", uid))
       .unique();
-    if (!player) throw appError("NOT_FOUND", "Player not found");
-    if (player.isHost) throw appError("CANNOT_KICK_HOST", "Cannot kick the host");
+    if (!player) throw apiError("NOT_FOUND", "Player not found");
+    if (player.isHost) throw apiError("CANNOT_KICK_HOST", "Cannot kick the host");
 
     const session = await ctx.db.get(sessionId);
-    if (!session) throw appError("NOT_FOUND", "Session not found");
+    if (!session) throw apiError("NOT_FOUND", "Session not found");
 
     // Delete all selections by the kicked player
     const selections = await ctx.db
@@ -222,7 +222,7 @@ export const getPlayers = query({
   args: { sessionId: v.id("sessions") },
   handler: async (ctx, { sessionId }) => {
     const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw appError("UNAUTHENTICATED", "Unauthenticated");
+    if (!identity) throw apiError("UNAUTHENTICATED", "Unauthenticated");
 
     return await ctx.db
       .query("players")

--- a/convex/reset.ts
+++ b/convex/reset.ts
@@ -4,6 +4,7 @@ import { isProd } from "./utils/env";
 export const clearAll = internalMutation({
   handler: async (ctx) => {
     // Runtime guard, independent of cron registration: also blocks a manual dashboard run.
+    // internal: plain Error — internalMutation, never reaches a client.
     if (isProd()) throw new Error("Refusing to clear data on a prod deployment");
 
     const tables = [

--- a/convex/rounds.ts
+++ b/convex/rounds.ts
@@ -5,6 +5,7 @@ import type { Id } from "./_generated/dataModel";
 import type { MutationCtx } from "./_generated/server";
 import { internalMutation, mutation, query } from "./_generated/server";
 import { requireSessionMember } from "./utils/auth";
+import { appError } from "./utils/errors";
 import { getRoundByNumber } from "./utils/rounds";
 
 export const getRound = query({
@@ -29,7 +30,7 @@ export const advanceRound = mutation({
   },
   handler: async (ctx, { sessionId, currentRoundNumber }) => {
     const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw new Error("Unauthenticated");
+    if (!identity) throw appError("UNAUTHENTICATED", "Unauthenticated");
 
     const currentRound = await ctx.db
       .query("rounds")
@@ -37,7 +38,7 @@ export const advanceRound = mutation({
       .filter((q) => q.eq(q.field("number"), currentRoundNumber))
       .unique();
 
-    if (!currentRound) throw new Error("Round not found");
+    if (!currentRound) throw appError("NOT_FOUND", "Round not found");
 
     if (currentRound.state === "revealing") {
       if (currentRound.revealJobId) {
@@ -58,7 +59,7 @@ export const advanceRound = mutation({
     }
 
     const session = await ctx.db.get(sessionId);
-    if (!session) throw new Error("Session not found");
+    if (!session) throw appError("NOT_FOUND", "Session not found");
 
     const revealDurationMs = session.playerCount * 4_000 + 5_000;
     const revealEndsAt = Date.now() + revealDurationMs;
@@ -86,7 +87,7 @@ export const completeReveal = internalMutation({
   },
   handler: async (ctx, { sessionId, roundNumber }) => {
     const round = await getRoundByNumber(ctx.db, sessionId, roundNumber);
-    if (!round) throw new Error("Round not found");
+    if (!round) throw appError("NOT_FOUND", "Round not found");
     if (round.state !== "revealing") return;
 
     return await completeRevealLogic(ctx, sessionId, roundNumber, round._id);
@@ -111,7 +112,7 @@ async function completeRevealLogic(
     const nextRoundNumber = roundNumber - 1;
 
     const nextRound = await getRoundByNumber(ctx.db, sessionId, nextRoundNumber);
-    if (!nextRound) throw new Error("Next round not found");
+    if (!nextRound) throw appError("NOT_FOUND", "Next round not found");
 
     await ctx.db.patch(nextRound._id, {
       state: "open",

--- a/convex/rounds.ts
+++ b/convex/rounds.ts
@@ -5,7 +5,7 @@ import type { Id } from "./_generated/dataModel";
 import type { MutationCtx } from "./_generated/server";
 import { internalMutation, mutation, query } from "./_generated/server";
 import { requireSessionMember } from "./utils/auth";
-import { appError } from "./utils/errors";
+import { apiError } from "./utils/errors";
 import { getRoundByNumber } from "./utils/rounds";
 
 export const getRound = query({
@@ -30,7 +30,7 @@ export const advanceRound = mutation({
   },
   handler: async (ctx, { sessionId, currentRoundNumber }) => {
     const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw appError("UNAUTHENTICATED", "Unauthenticated");
+    if (!identity) throw apiError("UNAUTHENTICATED", "Unauthenticated");
 
     const currentRound = await ctx.db
       .query("rounds")
@@ -38,7 +38,7 @@ export const advanceRound = mutation({
       .filter((q) => q.eq(q.field("number"), currentRoundNumber))
       .unique();
 
-    if (!currentRound) throw appError("NOT_FOUND", "Round not found");
+    if (!currentRound) throw apiError("NOT_FOUND", "Round not found");
 
     if (currentRound.state === "revealing") {
       if (currentRound.revealJobId) {
@@ -59,7 +59,7 @@ export const advanceRound = mutation({
     }
 
     const session = await ctx.db.get(sessionId);
-    if (!session) throw appError("NOT_FOUND", "Session not found");
+    if (!session) throw apiError("NOT_FOUND", "Session not found");
 
     const revealDurationMs = session.playerCount * 4_000 + 5_000;
     const revealEndsAt = Date.now() + revealDurationMs;
@@ -87,7 +87,7 @@ export const completeReveal = internalMutation({
   },
   handler: async (ctx, { sessionId, roundNumber }) => {
     const round = await getRoundByNumber(ctx.db, sessionId, roundNumber);
-    if (!round) throw appError("NOT_FOUND", "Round not found");
+    if (!round) throw apiError("NOT_FOUND", "Round not found");
     if (round.state !== "revealing") return;
 
     return await completeRevealLogic(ctx, sessionId, roundNumber, round._id);
@@ -112,7 +112,7 @@ async function completeRevealLogic(
     const nextRoundNumber = roundNumber - 1;
 
     const nextRound = await getRoundByNumber(ctx.db, sessionId, nextRoundNumber);
-    if (!nextRound) throw appError("NOT_FOUND", "Next round not found");
+    if (!nextRound) throw apiError("NOT_FOUND", "Next round not found");
 
     await ctx.db.patch(nextRound._id, {
       state: "open",

--- a/convex/selections.ts
+++ b/convex/selections.ts
@@ -6,6 +6,7 @@ import { mutation, query } from "./_generated/server";
 import { MAX_ROUNDS } from "./constants";
 import { rateLimiter } from "./ratelimits";
 import { requireSessionMember } from "./utils/auth";
+import { appError } from "./utils/errors";
 import { buildPickArg } from "./utils/pick";
 import { getRoundByNumber } from "./utils/rounds";
 
@@ -68,21 +69,21 @@ export const saveSelection = mutation({
   },
   handler: async (ctx, { sessionId, roundNumber, option }) => {
     const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw new Error("Unauthenticated");
+    if (!identity) throw appError("UNAUTHENTICATED", "Unauthenticated");
     const uid = identity.subject;
 
     await rateLimiter.limit(ctx, "saveSelection", { key: uid, throws: true });
 
     const round = await getRoundByNumber(ctx.db, sessionId, roundNumber);
-    if (!round) throw new Error("Round not found");
-    if (round.state !== "open") throw new Error("Round is not open");
+    if (!round) throw appError("NOT_FOUND", "Round not found");
+    if (round.state !== "open") throw appError("WRONG_STATE", "Round is not open");
 
     const existing = await ctx.db
       .query("selections")
       .withIndex("by_round_uid", (q) => q.eq("roundId", round._id).eq("uid", uid))
       .unique();
 
-    if (existing) throw new Error("Selection already exists for this round");
+    if (existing) throw appError("ALREADY_SELECTED", "Selection already exists for this round");
 
     await ctx.db.insert("selections", {
       sessionId,
@@ -98,7 +99,7 @@ export const saveSelection = mutation({
     await ctx.db.patch(round._id, { selectionsComplete });
 
     const session = await ctx.db.get(sessionId);
-    if (!session) throw new Error("Session not found");
+    if (!session) throw appError("NOT_FOUND", "Session not found");
 
     const allComplete = selectionsComplete > 0 && selectionsComplete >= session.playerCount;
 
@@ -129,18 +130,18 @@ export const editSelection = mutation({
   },
   handler: async (ctx, { sessionId, roundNumber, option }) => {
     const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw new Error("Unauthenticated");
+    if (!identity) throw appError("UNAUTHENTICATED", "Unauthenticated");
     const uid = identity.subject;
 
     const round = await getRoundByNumber(ctx.db, sessionId, roundNumber);
-    if (!round) throw new Error("Round not found");
+    if (!round) throw appError("NOT_FOUND", "Round not found");
 
     const existing = await ctx.db
       .query("selections")
       .withIndex("by_round_uid", (q) => q.eq("roundId", round._id).eq("uid", uid))
       .unique();
 
-    if (!existing) throw new Error("Selection not found");
+    if (!existing) throw appError("NOT_FOUND", "Selection not found");
 
     await ctx.db.patch(existing._id, {
       pick: buildPickArg(option),

--- a/convex/selections.ts
+++ b/convex/selections.ts
@@ -6,7 +6,7 @@ import { mutation, query } from "./_generated/server";
 import { MAX_ROUNDS } from "./constants";
 import { rateLimiter } from "./ratelimits";
 import { requireSessionMember } from "./utils/auth";
-import { appError } from "./utils/errors";
+import { apiError } from "./utils/errors";
 import { buildPickArg } from "./utils/pick";
 import { getRoundByNumber } from "./utils/rounds";
 
@@ -69,21 +69,21 @@ export const saveSelection = mutation({
   },
   handler: async (ctx, { sessionId, roundNumber, option }) => {
     const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw appError("UNAUTHENTICATED", "Unauthenticated");
+    if (!identity) throw apiError("UNAUTHENTICATED", "Unauthenticated");
     const uid = identity.subject;
 
     await rateLimiter.limit(ctx, "saveSelection", { key: uid, throws: true });
 
     const round = await getRoundByNumber(ctx.db, sessionId, roundNumber);
-    if (!round) throw appError("NOT_FOUND", "Round not found");
-    if (round.state !== "open") throw appError("WRONG_STATE", "Round is not open");
+    if (!round) throw apiError("NOT_FOUND", "Round not found");
+    if (round.state !== "open") throw apiError("WRONG_STATE", "Round is not open");
 
     const existing = await ctx.db
       .query("selections")
       .withIndex("by_round_uid", (q) => q.eq("roundId", round._id).eq("uid", uid))
       .unique();
 
-    if (existing) throw appError("ALREADY_SELECTED", "Selection already exists for this round");
+    if (existing) throw apiError("ALREADY_SELECTED", "Selection already exists for this round");
 
     await ctx.db.insert("selections", {
       sessionId,
@@ -99,7 +99,7 @@ export const saveSelection = mutation({
     await ctx.db.patch(round._id, { selectionsComplete });
 
     const session = await ctx.db.get(sessionId);
-    if (!session) throw appError("NOT_FOUND", "Session not found");
+    if (!session) throw apiError("NOT_FOUND", "Session not found");
 
     const allComplete = selectionsComplete > 0 && selectionsComplete >= session.playerCount;
 
@@ -130,18 +130,18 @@ export const editSelection = mutation({
   },
   handler: async (ctx, { sessionId, roundNumber, option }) => {
     const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw appError("UNAUTHENTICATED", "Unauthenticated");
+    if (!identity) throw apiError("UNAUTHENTICATED", "Unauthenticated");
     const uid = identity.subject;
 
     const round = await getRoundByNumber(ctx.db, sessionId, roundNumber);
-    if (!round) throw appError("NOT_FOUND", "Round not found");
+    if (!round) throw apiError("NOT_FOUND", "Round not found");
 
     const existing = await ctx.db
       .query("selections")
       .withIndex("by_round_uid", (q) => q.eq("roundId", round._id).eq("uid", uid))
       .unique();
 
-    if (!existing) throw appError("NOT_FOUND", "Selection not found");
+    if (!existing) throw apiError("NOT_FOUND", "Selection not found");
 
     await ctx.db.patch(existing._id, {
       pick: buildPickArg(option),

--- a/convex/sessions.ts
+++ b/convex/sessions.ts
@@ -3,14 +3,14 @@ import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
 import { MAX_PLAYERS, MAX_ROUNDS, SessionStatus } from "./constants";
 import { rateLimiter } from "./ratelimits";
-import { appError } from "./utils/errors";
+import { apiError } from "./utils/errors";
 import { validateAvatar, validateName } from "./utils/validate";
 
 export const getSession = query({
   args: { sessionId: v.id("sessions") },
   handler: async (ctx, { sessionId }) => {
     const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw appError("UNAUTHENTICATED", "Unauthenticated");
+    if (!identity) throw apiError("UNAUTHENTICATED", "Unauthenticated");
 
     return await ctx.db.get(sessionId);
   },
@@ -25,12 +25,12 @@ export const createSession = mutation({
   },
   handler: async (ctx, { topic, year, name, avatar }) => {
     const nameError = validateName(name);
-    if (nameError) throw appError("VALIDATION", nameError);
+    if (nameError) throw apiError("VALIDATION", nameError);
     const avatarError = validateAvatar(avatar);
-    if (avatarError) throw appError("VALIDATION", avatarError);
+    if (avatarError) throw apiError("VALIDATION", avatarError);
 
     const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw appError("UNAUTHENTICATED", "Unauthenticated");
+    if (!identity) throw apiError("UNAUTHENTICATED", "Unauthenticated");
     const uid = identity.subject;
 
     await rateLimiter.limit(ctx, "createSession", { key: uid, throws: true });
@@ -79,17 +79,17 @@ export const endSession = mutation({
   },
   handler: async (ctx, { sessionId }) => {
     const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw appError("UNAUTHENTICATED", "Unauthenticated");
+    if (!identity) throw apiError("UNAUTHENTICATED", "Unauthenticated");
 
     const host = await ctx.db
       .query("players")
       .withIndex("by_session_uid", (q) => q.eq("sessionId", sessionId).eq("uid", identity.subject))
       .unique();
 
-    if (!host?.isHost) throw appError("NOT_HOST", "Only the host can end the session");
+    if (!host?.isHost) throw apiError("NOT_HOST", "Only the host can end the session");
 
     const session = await ctx.db.get(sessionId);
-    if (!session) throw appError("NOT_FOUND", "Session not found");
+    if (!session) throw apiError("NOT_FOUND", "Session not found");
 
     await ctx.db.patch(sessionId, { status: SessionStatus.ENDED });
   },
@@ -101,17 +101,17 @@ export const startSession = mutation({
   },
   handler: async (ctx, { sessionId }) => {
     const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw appError("UNAUTHENTICATED", "Unauthenticated");
+    if (!identity) throw apiError("UNAUTHENTICATED", "Unauthenticated");
 
     const session = await ctx.db.get(sessionId);
-    if (!session) throw appError("NOT_FOUND", "Session not found");
+    if (!session) throw apiError("NOT_FOUND", "Session not found");
 
     const host = await ctx.db
       .query("players")
       .withIndex("by_session_uid", (q) => q.eq("sessionId", sessionId).eq("uid", identity.subject))
       .unique();
 
-    if (!host?.isHost) throw appError("NOT_HOST", "Only the host can start the session");
+    if (!host?.isHost) throw apiError("NOT_HOST", "Only the host can start the session");
 
     const round = await ctx.db
       .query("rounds")
@@ -119,7 +119,7 @@ export const startSession = mutation({
       .filter((q) => q.eq(q.field("number"), MAX_ROUNDS))
       .unique();
 
-    if (!round) throw appError("NOT_FOUND", "Round not found");
+    if (!round) throw apiError("NOT_FOUND", "Round not found");
 
     await ctx.db.patch(sessionId, {
       activeRoundNumber: MAX_ROUNDS,

--- a/convex/sessions.ts
+++ b/convex/sessions.ts
@@ -3,13 +3,14 @@ import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
 import { MAX_PLAYERS, MAX_ROUNDS, SessionStatus } from "./constants";
 import { rateLimiter } from "./ratelimits";
+import { appError } from "./utils/errors";
 import { validateAvatar, validateName } from "./utils/validate";
 
 export const getSession = query({
   args: { sessionId: v.id("sessions") },
   handler: async (ctx, { sessionId }) => {
     const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw new Error("Unauthenticated");
+    if (!identity) throw appError("UNAUTHENTICATED", "Unauthenticated");
 
     return await ctx.db.get(sessionId);
   },
@@ -24,12 +25,12 @@ export const createSession = mutation({
   },
   handler: async (ctx, { topic, year, name, avatar }) => {
     const nameError = validateName(name);
-    if (nameError) throw new Error(nameError);
+    if (nameError) throw appError("VALIDATION", nameError);
     const avatarError = validateAvatar(avatar);
-    if (avatarError) throw new Error(avatarError);
+    if (avatarError) throw appError("VALIDATION", avatarError);
 
     const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw new Error("Unauthenticated");
+    if (!identity) throw appError("UNAUTHENTICATED", "Unauthenticated");
     const uid = identity.subject;
 
     await rateLimiter.limit(ctx, "createSession", { key: uid, throws: true });
@@ -78,17 +79,17 @@ export const endSession = mutation({
   },
   handler: async (ctx, { sessionId }) => {
     const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw new Error("Unauthenticated");
+    if (!identity) throw appError("UNAUTHENTICATED", "Unauthenticated");
 
     const host = await ctx.db
       .query("players")
       .withIndex("by_session_uid", (q) => q.eq("sessionId", sessionId).eq("uid", identity.subject))
       .unique();
 
-    if (!host?.isHost) throw new Error("Only the host can end the session");
+    if (!host?.isHost) throw appError("NOT_HOST", "Only the host can end the session");
 
     const session = await ctx.db.get(sessionId);
-    if (!session) throw new Error("Session not found");
+    if (!session) throw appError("NOT_FOUND", "Session not found");
 
     await ctx.db.patch(sessionId, { status: SessionStatus.ENDED });
   },
@@ -100,17 +101,17 @@ export const startSession = mutation({
   },
   handler: async (ctx, { sessionId }) => {
     const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw new Error("Unauthenticated");
+    if (!identity) throw appError("UNAUTHENTICATED", "Unauthenticated");
 
     const session = await ctx.db.get(sessionId);
-    if (!session) throw new Error("Session not found");
+    if (!session) throw appError("NOT_FOUND", "Session not found");
 
     const host = await ctx.db
       .query("players")
       .withIndex("by_session_uid", (q) => q.eq("sessionId", sessionId).eq("uid", identity.subject))
       .unique();
 
-    if (!host?.isHost) throw new Error("Only the host can start the session");
+    if (!host?.isHost) throw appError("NOT_HOST", "Only the host can start the session");
 
     const round = await ctx.db
       .query("rounds")
@@ -118,7 +119,7 @@ export const startSession = mutation({
       .filter((q) => q.eq(q.field("number"), MAX_ROUNDS))
       .unique();
 
-    if (!round) throw new Error("Round not found");
+    if (!round) throw appError("NOT_FOUND", "Round not found");
 
     await ctx.db.patch(sessionId, {
       activeRoundNumber: MAX_ROUNDS,

--- a/convex/test/seed.ts
+++ b/convex/test/seed.ts
@@ -1,3 +1,4 @@
+// internal: test-only seeding; plain Error throws are fine here (never reachable on prod)
 import { v } from "convex/values";
 
 import { internalMutation } from "../_generated/server";

--- a/convex/tmdb.ts
+++ b/convex/tmdb.ts
@@ -36,6 +36,7 @@ export const getMovies = action({
         `https://api.themoviedb.org/3/discover/movie?api_key=${process.env.TMDB_API_KEY}&primary_release_date.gte=${startDate}&primary_release_date.lte=${endDate}&sort_by=popularity.desc&language=en-US&page=${page}`,
       );
 
+      // internal: plain Error — nothing user-actionable; UI shows its generic load failure
       if (!response.ok) throw new Error(`TMDB error: ${response.status}`);
 
       const data: TMDBResponse = await response.json();

--- a/convex/utils/auth.ts
+++ b/convex/utils/auth.ts
@@ -1,10 +1,10 @@
 import type { Id } from "../_generated/dataModel";
 import type { QueryCtx } from "../_generated/server";
-import { appError } from "./errors";
+import { apiError } from "./errors";
 
 export async function requireSessionMember(ctx: QueryCtx, sessionId: Id<"sessions">) {
   const identity = await ctx.auth.getUserIdentity();
-  if (!identity) throw appError("UNAUTHENTICATED", "Unauthenticated");
+  if (!identity) throw apiError("UNAUTHENTICATED", "Unauthenticated");
 
   const player = await ctx.db
     .query("players")

--- a/convex/utils/auth.ts
+++ b/convex/utils/auth.ts
@@ -1,9 +1,10 @@
 import type { Id } from "../_generated/dataModel";
 import type { QueryCtx } from "../_generated/server";
+import { appError } from "./errors";
 
 export async function requireSessionMember(ctx: QueryCtx, sessionId: Id<"sessions">) {
   const identity = await ctx.auth.getUserIdentity();
-  if (!identity) throw new Error("Unauthenticated");
+  if (!identity) throw appError("UNAUTHENTICATED", "Unauthenticated");
 
   const player = await ctx.db
     .query("players")

--- a/convex/utils/dates.ts
+++ b/convex/utils/dates.ts
@@ -3,6 +3,7 @@ const START_YEAR = 1987;
 export function currentYear(yearString: string) {
   const year = parseInt(yearString, 10);
   if (isNaN(year) || year < START_YEAR || year > new Date().getFullYear())
+    // internal: plain Error — year is validated by the arg validator upstream
     throw new Error("Invalid year");
   const startDate = new Date(year, 0, 1).getTime() / 1000;
   const endDate = new Date(year + 1, 0, 1).getTime() / 1000;

--- a/convex/utils/errors.ts
+++ b/convex/utils/errors.ts
@@ -22,9 +22,9 @@ export const ERROR_CODES = {
 
 export type ErrorCode = (typeof ERROR_CODES)[keyof typeof ERROR_CODES];
 
-export type AppErrorData = { code: ErrorCode; message: string };
+export type ApiErrorData = { code: ErrorCode; message: string };
 
-/** Build a client-visible error: `throw appError("NOT_HOST", "Only the host can kick players")`. */
-export function appError(code: ErrorCode, message: string): ConvexError<AppErrorData> {
+/** Build a client-visible error: `throw apiError("NOT_HOST", "Only the host can kick players")`. */
+export function apiError(code: ErrorCode, message: string): ConvexError<ApiErrorData> {
   return new ConvexError({ code, message });
 }

--- a/convex/utils/errors.ts
+++ b/convex/utils/errors.ts
@@ -1,0 +1,30 @@
+import { ConvexError } from "convex/values";
+
+/**
+ * Codes for user-facing failures. `code` is for branching in the client,
+ * `message` is for humans. Plain `Error` messages are redacted on prod
+ * deployments; only `ConvexError.data` reaches the client.
+ */
+export const ERROR_CODES = {
+  UNAUTHENTICATED: "UNAUTHENTICATED",
+  NOT_FOUND: "NOT_FOUND",
+  NOT_MEMBER: "NOT_MEMBER",
+  NOT_HOST: "NOT_HOST",
+  WRONG_STATE: "WRONG_STATE",
+  SESSION_FULL: "SESSION_FULL",
+  SESSION_CLOSED: "SESSION_CLOSED",
+  ALREADY_JOINED: "ALREADY_JOINED",
+  ALREADY_SELECTED: "ALREADY_SELECTED",
+  HOST_CANNOT_LEAVE: "HOST_CANNOT_LEAVE",
+  CANNOT_KICK_HOST: "CANNOT_KICK_HOST",
+  VALIDATION: "VALIDATION",
+} as const;
+
+export type ErrorCode = (typeof ERROR_CODES)[keyof typeof ERROR_CODES];
+
+export type AppErrorData = { code: ErrorCode; message: string };
+
+/** Build a client-visible error: `throw appError("NOT_HOST", "Only the host can kick players")`. */
+export function appError(code: ErrorCode, message: string): ConvexError<AppErrorData> {
+  return new ConvexError({ code, message });
+}

--- a/src/components/sidebar/sidebar-content.tsx
+++ b/src/components/sidebar/sidebar-content.tsx
@@ -4,12 +4,14 @@ import { useNavigate } from "@tanstack/react-router";
 import { Button } from "components/button";
 import { PlayerList } from "components/lists/players";
 import { Loading } from "components/states/loading";
+import { useToast } from "components/toast/use-toast";
 import { api } from "convex/_generated/api";
 import { useMutation } from "convex/react";
 import type { SessionID } from "db/types";
 import { usePlayers } from "db/use-players";
 import { useSelections } from "db/use-selections";
 import { useSession } from "db/use-sessions";
+import { getAppError } from "utils/app-error";
 import { tryCatch } from "utils/try-catch";
 
 export interface SidebarContentProps {
@@ -21,6 +23,7 @@ export interface SidebarContentProps {
 
 export function SidebarContent({ sessionId, topic, year, handleClose }: SidebarContentProps) {
   const navigate = useNavigate();
+  const toast = useToast();
   const { session, activeRound } = useSession(sessionId);
   const { players, isHost } = usePlayers(sessionId);
   const { selections } = useSelections(sessionId, activeRound);
@@ -40,6 +43,7 @@ export function SidebarContent({ sessionId, topic, year, handleClose }: SidebarC
     );
     if (error) {
       Sentry.captureException(error);
+      toast.show({ message: getAppError(error).message, variant: "error" });
       return;
     }
     if (!data.hasNextRound) {
@@ -54,14 +58,21 @@ export function SidebarContent({ sessionId, topic, year, handleClose }: SidebarC
   const onLeaveGame = async () => {
     const mutation = isHost ? endSession({ sessionId }) : leaveSession({ sessionId });
     const { error } = await tryCatch(mutation);
-    if (error) Sentry.captureException(error);
+    if (error) {
+      // Leave the room regardless — the player is done here either way.
+      Sentry.captureException(error);
+      toast.show({ message: getAppError(error).message, variant: "error" });
+    }
     navigate({ to: "/", replace: true });
   };
 
   const onKick = async (uid: string) => {
     if (!isHost) return;
     const { error } = await tryCatch(kickFromGame({ sessionId, uid }));
-    if (error) Sentry.captureException(error);
+    if (error) {
+      Sentry.captureException(error);
+      toast.show({ message: getAppError(error).message, variant: "error" });
+    }
   };
 
   return (

--- a/src/components/sidebar/sidebar-content.tsx
+++ b/src/components/sidebar/sidebar-content.tsx
@@ -11,7 +11,7 @@ import type { SessionID } from "db/types";
 import { usePlayers } from "db/use-players";
 import { useSelections } from "db/use-selections";
 import { useSession } from "db/use-sessions";
-import { getAppError } from "utils/app-error";
+import { getApiError } from "utils/api-error";
 import { tryCatch } from "utils/try-catch";
 
 export interface SidebarContentProps {
@@ -43,7 +43,7 @@ export function SidebarContent({ sessionId, topic, year, handleClose }: SidebarC
     );
     if (error) {
       Sentry.captureException(error);
-      toast.show({ message: getAppError(error).message, variant: "error" });
+      toast.show({ message: getApiError(error).message, variant: "error" });
       return;
     }
     if (!data.hasNextRound) {
@@ -61,7 +61,7 @@ export function SidebarContent({ sessionId, topic, year, handleClose }: SidebarC
     if (error) {
       // Leave the room regardless — the player is done here either way.
       Sentry.captureException(error);
-      toast.show({ message: getAppError(error).message, variant: "error" });
+      toast.show({ message: getApiError(error).message, variant: "error" });
     }
     navigate({ to: "/", replace: true });
   };
@@ -71,7 +71,7 @@ export function SidebarContent({ sessionId, topic, year, handleClose }: SidebarC
     const { error } = await tryCatch(kickFromGame({ sessionId, uid }));
     if (error) {
       Sentry.captureException(error);
-      toast.show({ message: getAppError(error).message, variant: "error" });
+      toast.show({ message: getApiError(error).message, variant: "error" });
     }
   };
 

--- a/src/screens/lobby/lobby.tsx
+++ b/src/screens/lobby/lobby.tsx
@@ -10,6 +10,7 @@ import { useToast } from "components/toast/use-toast";
 import { api } from "convex/_generated/api";
 import { MAX_ROUNDS } from "convex/constants";
 import { useMutation } from "convex/react";
+import { getAppError } from "utils/app-error";
 import { tryCatch } from "utils/try-catch";
 
 import { Topic } from "../topic";
@@ -40,6 +41,7 @@ export function Lobby({ topic, year, sessionId }: LobbyProps) {
     const { error } = await tryCatch(startSession({ sessionId }));
     if (error) {
       Sentry.captureException(error);
+      toast.show({ message: getAppError(error).message, variant: "error" });
       return;
     }
     navigate({
@@ -53,6 +55,7 @@ export function Lobby({ topic, year, sessionId }: LobbyProps) {
     const { error } = await tryCatch(leaveSession({ sessionId }));
     if (error) {
       Sentry.captureException(error);
+      toast.show({ message: getAppError(error).message, variant: "error" });
       return;
     }
     navigate({ to: "/", replace: true });

--- a/src/screens/lobby/lobby.tsx
+++ b/src/screens/lobby/lobby.tsx
@@ -10,7 +10,7 @@ import { useToast } from "components/toast/use-toast";
 import { api } from "convex/_generated/api";
 import { MAX_ROUNDS } from "convex/constants";
 import { useMutation } from "convex/react";
-import { getAppError } from "utils/app-error";
+import { getApiError } from "utils/api-error";
 import { tryCatch } from "utils/try-catch";
 
 import { Topic } from "../topic";
@@ -41,7 +41,7 @@ export function Lobby({ topic, year, sessionId }: LobbyProps) {
     const { error } = await tryCatch(startSession({ sessionId }));
     if (error) {
       Sentry.captureException(error);
-      toast.show({ message: getAppError(error).message, variant: "error" });
+      toast.show({ message: getApiError(error).message, variant: "error" });
       return;
     }
     navigate({
@@ -55,7 +55,7 @@ export function Lobby({ topic, year, sessionId }: LobbyProps) {
     const { error } = await tryCatch(leaveSession({ sessionId }));
     if (error) {
       Sentry.captureException(error);
-      toast.show({ message: getAppError(error).message, variant: "error" });
+      toast.show({ message: getApiError(error).message, variant: "error" });
       return;
     }
     navigate({ to: "/", replace: true });

--- a/src/screens/round/round.tsx
+++ b/src/screens/round/round.tsx
@@ -15,7 +15,7 @@ import { useMutation } from "convex/react";
 import type { SessionID } from "db/types";
 import { useTopicData } from "queries/use-topic-data";
 import type { Option } from "types/option";
-import { getAppError } from "utils/app-error";
+import { getApiError } from "utils/api-error";
 import { tryCatch } from "utils/try-catch";
 
 import { Reveal } from "./reveal";
@@ -69,7 +69,7 @@ export function Round({ sessionId, topic, year }: Props) {
       );
       if (error) {
         Sentry.captureException(error);
-        toast.show({ message: getAppError(error).message, variant: "error" });
+        toast.show({ message: getApiError(error).message, variant: "error" });
         return;
       }
       if (!data.hasNextRound) {
@@ -103,7 +103,7 @@ export function Round({ sessionId, topic, year }: Props) {
       );
       if (error) {
         Sentry.captureException(error);
-        toast.show({ message: getAppError(error).message, variant: "error" });
+        toast.show({ message: getApiError(error).message, variant: "error" });
         return;
       }
       setEditingRound(null);
@@ -117,7 +117,7 @@ export function Round({ sessionId, topic, year }: Props) {
       );
       if (error) {
         Sentry.captureException(error);
-        toast.show({ message: getAppError(error).message, variant: "error" });
+        toast.show({ message: getApiError(error).message, variant: "error" });
         return;
       }
     }

--- a/src/screens/round/round.tsx
+++ b/src/screens/round/round.tsx
@@ -8,12 +8,14 @@ import { Container } from "components/container";
 import { Picks } from "components/lists/picks";
 import { DisplayError } from "components/states/error";
 import { Loading } from "components/states/loading";
+import { useToast } from "components/toast/use-toast";
 import type { TOPIC_KEY } from "constants/topics";
 import { api } from "convex/_generated/api";
 import { useMutation } from "convex/react";
 import type { SessionID } from "db/types";
 import { useTopicData } from "queries/use-topic-data";
 import type { Option } from "types/option";
+import { getAppError } from "utils/app-error";
 import { tryCatch } from "utils/try-catch";
 
 import { Reveal } from "./reveal";
@@ -28,6 +30,7 @@ interface Props {
 
 export function Round({ sessionId, topic, year }: Props) {
   const navigate = useNavigate();
+  const toast = useToast();
   const {
     isLoading,
     session,
@@ -66,6 +69,7 @@ export function Round({ sessionId, topic, year }: Props) {
       );
       if (error) {
         Sentry.captureException(error);
+        toast.show({ message: getAppError(error).message, variant: "error" });
         return;
       }
       if (!data.hasNextRound) {
@@ -99,6 +103,7 @@ export function Round({ sessionId, topic, year }: Props) {
       );
       if (error) {
         Sentry.captureException(error);
+        toast.show({ message: getAppError(error).message, variant: "error" });
         return;
       }
       setEditingRound(null);
@@ -112,6 +117,7 @@ export function Round({ sessionId, topic, year }: Props) {
       );
       if (error) {
         Sentry.captureException(error);
+        toast.show({ message: getAppError(error).message, variant: "error" });
         return;
       }
     }

--- a/src/screens/topic/topic.tsx
+++ b/src/screens/topic/topic.tsx
@@ -13,7 +13,7 @@ import { useMutation } from "convex/react";
 import { MAX_NAME_LENGTH, validateName } from "convex/utils/validate";
 import type { SessionID } from "db/types";
 import { useTopicData } from "queries/use-topic-data";
-import { getAppError } from "utils/app-error";
+import { getApiError } from "utils/api-error";
 import { tryCatch } from "utils/try-catch";
 
 interface Props {
@@ -41,9 +41,9 @@ export function Topic({ topic, year, existingSessionId }: Props) {
       const { error } = await tryCatch(mutateJoin({ sessionId: existingSessionId, name, avatar }));
       if (error) {
         // Expected when the player is already in: fall through to the lobby, no toast.
-        if (getAppError(error).code === "ALREADY_JOINED") return;
+        if (getApiError(error).code === "ALREADY_JOINED") return;
         Sentry.captureException(error);
-        toast.show({ message: getAppError(error).message, variant: "error" });
+        toast.show({ message: getApiError(error).message, variant: "error" });
         return;
       }
     } else {
@@ -52,7 +52,7 @@ export function Topic({ topic, year, existingSessionId }: Props) {
       );
       if (error) {
         Sentry.captureException(error);
-        toast.show({ message: getAppError(error).message, variant: "error" });
+        toast.show({ message: getApiError(error).message, variant: "error" });
         return;
       }
       navigate({

--- a/src/screens/topic/topic.tsx
+++ b/src/screens/topic/topic.tsx
@@ -6,12 +6,14 @@ import { Avatar, useRandomAvatar } from "components/avatar";
 import { Button } from "components/button";
 import { Container } from "components/container";
 import { Input } from "components/input";
+import { useToast } from "components/toast/use-toast";
 import type { TopicType } from "constants/topics";
 import { api } from "convex/_generated/api";
 import { useMutation } from "convex/react";
 import { MAX_NAME_LENGTH, validateName } from "convex/utils/validate";
 import type { SessionID } from "db/types";
 import { useTopicData } from "queries/use-topic-data";
+import { getAppError } from "utils/app-error";
 import { tryCatch } from "utils/try-catch";
 
 interface Props {
@@ -22,6 +24,7 @@ interface Props {
 
 export function Topic({ topic, year, existingSessionId }: Props) {
   const navigate = useNavigate();
+  const toast = useToast();
   const { isLoading } = useTopicData({ key: topic.value, year });
   const mutateJoin = useMutation(api.players.joinSession);
   const mutateCreate = useMutation(api.sessions.createSession);
@@ -37,8 +40,10 @@ export function Topic({ topic, year, existingSessionId }: Props) {
     if (isJoining) {
       const { error } = await tryCatch(mutateJoin({ sessionId: existingSessionId, name, avatar }));
       if (error) {
-        if (error.message === "Already joined this session") return;
+        // Expected when the player is already in: fall through to the lobby, no toast.
+        if (getAppError(error).code === "ALREADY_JOINED") return;
         Sentry.captureException(error);
+        toast.show({ message: getAppError(error).message, variant: "error" });
         return;
       }
     } else {
@@ -47,6 +52,7 @@ export function Topic({ topic, year, existingSessionId }: Props) {
       );
       if (error) {
         Sentry.captureException(error);
+        toast.show({ message: getAppError(error).message, variant: "error" });
         return;
       }
       navigate({

--- a/src/shared/__tests__/api-error.test.ts
+++ b/src/shared/__tests__/api-error.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from "bun:test";
 
-import { appError } from "convex/utils/errors";
+import { apiError } from "convex/utils/errors";
 import { ConvexError } from "convex/values";
-import { getAppError } from "utils/app-error";
+import { getApiError } from "utils/api-error";
 
-describe("getAppError", () => {
+describe("getApiError", () => {
   it("passes through app errors unchanged", () => {
-    const error = appError("ALREADY_JOINED", "Already joined this session");
-    expect(getAppError(error)).toEqual({
+    const error = apiError("ALREADY_JOINED", "Already joined this session");
+    expect(getApiError(error)).toEqual({
       code: "ALREADY_JOINED",
       message: "Already joined this session",
     });
@@ -15,23 +15,23 @@ describe("getAppError", () => {
 
   it("maps the rate-limiter's ConvexError to RATE_LIMITED", () => {
     const error = new ConvexError({ kind: "RateLimited", name: "joinSession", retryAfter: 1200 });
-    expect(getAppError(error)).toEqual({
+    expect(getApiError(error)).toEqual({
       code: "RATE_LIMITED",
       message: "Slow down and try again",
     });
   });
 
   it("does not leak a plain Error's message", () => {
-    expect(getAppError(new Error("db exploded"))).toEqual({
+    expect(getApiError(new Error("db exploded"))).toEqual({
       code: "UNKNOWN",
       message: "Something went wrong",
     });
   });
 
   it("falls back for non-Error throwables and unrecognized ConvexError data", () => {
-    expect(getAppError("nope").code).toBe("UNKNOWN");
-    expect(getAppError(undefined).code).toBe("UNKNOWN");
-    expect(getAppError(new ConvexError("string data")).code).toBe("UNKNOWN");
-    expect(getAppError(new ConvexError({ code: 42 })).code).toBe("UNKNOWN");
+    expect(getApiError("nope").code).toBe("UNKNOWN");
+    expect(getApiError(undefined).code).toBe("UNKNOWN");
+    expect(getApiError(new ConvexError("string data")).code).toBe("UNKNOWN");
+    expect(getApiError(new ConvexError({ code: 42 })).code).toBe("UNKNOWN");
   });
 });

--- a/src/shared/__tests__/app-error.test.ts
+++ b/src/shared/__tests__/app-error.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+
+import { appError } from "convex/utils/errors";
+import { ConvexError } from "convex/values";
+import { getAppError } from "utils/app-error";
+
+describe("getAppError", () => {
+  it("passes through app errors unchanged", () => {
+    const error = appError("ALREADY_JOINED", "Already joined this session");
+    expect(getAppError(error)).toEqual({
+      code: "ALREADY_JOINED",
+      message: "Already joined this session",
+    });
+  });
+
+  it("maps the rate-limiter's ConvexError to RATE_LIMITED", () => {
+    const error = new ConvexError({ kind: "RateLimited", name: "joinSession", retryAfter: 1200 });
+    expect(getAppError(error)).toEqual({
+      code: "RATE_LIMITED",
+      message: "Slow down and try again",
+    });
+  });
+
+  it("does not leak a plain Error's message", () => {
+    expect(getAppError(new Error("db exploded"))).toEqual({
+      code: "UNKNOWN",
+      message: "Something went wrong",
+    });
+  });
+
+  it("falls back for non-Error throwables and unrecognized ConvexError data", () => {
+    expect(getAppError("nope").code).toBe("UNKNOWN");
+    expect(getAppError(undefined).code).toBe("UNKNOWN");
+    expect(getAppError(new ConvexError("string data")).code).toBe("UNKNOWN");
+    expect(getAppError(new ConvexError({ code: 42 })).code).toBe("UNKNOWN");
+  });
+});

--- a/src/shared/__tests__/errors.test.ts
+++ b/src/shared/__tests__/errors.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "bun:test";
 
-import { appError } from "convex/utils/errors";
+import { apiError } from "convex/utils/errors";
 import { ConvexError } from "convex/values";
 
-describe("appError", () => {
+describe("apiError", () => {
   it("returns a ConvexError carrying exactly { code, message }", () => {
-    const error = appError("NOT_HOST", "Only the host can kick players");
+    const error = apiError("NOT_HOST", "Only the host can kick players");
     expect(error).toBeInstanceOf(ConvexError);
     expect(error.data).toEqual({ code: "NOT_HOST", message: "Only the host can kick players" });
   });

--- a/src/shared/__tests__/errors.test.ts
+++ b/src/shared/__tests__/errors.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "bun:test";
+
+import { appError } from "convex/utils/errors";
+import { ConvexError } from "convex/values";
+
+describe("appError", () => {
+  it("returns a ConvexError carrying exactly { code, message }", () => {
+    const error = appError("NOT_HOST", "Only the host can kick players");
+    expect(error).toBeInstanceOf(ConvexError);
+    expect(error.data).toEqual({ code: "NOT_HOST", message: "Only the host can kick players" });
+  });
+});

--- a/src/utils/api-error.ts
+++ b/src/utils/api-error.ts
@@ -1,7 +1,7 @@
-import type { AppErrorData, ErrorCode } from "convex/utils/errors";
+import type { ApiErrorData, ErrorCode } from "convex/utils/errors";
 import { ConvexError } from "convex/values";
 
-/** Client-only codes for failures that did not originate from `appError`. */
+/** Client-only codes for failures that did not originate from `apiError`. */
 type ClientErrorCode = ErrorCode | "RATE_LIMITED" | "UNKNOWN";
 
 export type ClientError = { code: ClientErrorCode; message: string };
@@ -9,12 +9,12 @@ export type ClientError = { code: ClientErrorCode; message: string };
 const RATE_LIMITED: ClientError = { code: "RATE_LIMITED", message: "Slow down and try again" };
 const UNKNOWN: ClientError = { code: "UNKNOWN", message: "Something went wrong" };
 
-function isAppErrorData(data: unknown): data is AppErrorData {
+function isApiErrorData(data: unknown): data is ApiErrorData {
   return (
     typeof data === "object" &&
     data !== null &&
-    typeof (data as AppErrorData).code === "string" &&
-    typeof (data as AppErrorData).message === "string"
+    typeof (data as ApiErrorData).code === "string" &&
+    typeof (data as ApiErrorData).message === "string"
   );
 }
 
@@ -23,10 +23,10 @@ function isAppErrorData(data: unknown): data is AppErrorData {
  * Never surfaces the underlying message for non-app errors — on prod it is
  * redacted to "Server Error" anyway, and on dev it may leak internals.
  */
-export function getAppError(error: unknown): ClientError {
+export function getApiError(error: unknown): ClientError {
   if (!(error instanceof ConvexError)) return UNKNOWN;
   const data: unknown = error.data;
-  if (isAppErrorData(data)) return { code: data.code, message: data.message };
+  if (isApiErrorData(data)) return { code: data.code, message: data.message };
   // Shape thrown by @convex-dev/rate-limiter with `throws: true`.
   if (
     typeof data === "object" &&

--- a/src/utils/app-error.ts
+++ b/src/utils/app-error.ts
@@ -1,0 +1,38 @@
+import type { AppErrorData, ErrorCode } from "convex/utils/errors";
+import { ConvexError } from "convex/values";
+
+/** Client-only codes for failures that did not originate from `appError`. */
+type ClientErrorCode = ErrorCode | "RATE_LIMITED" | "UNKNOWN";
+
+export type ClientError = { code: ClientErrorCode; message: string };
+
+const RATE_LIMITED: ClientError = { code: "RATE_LIMITED", message: "Slow down and try again" };
+const UNKNOWN: ClientError = { code: "UNKNOWN", message: "Something went wrong" };
+
+function isAppErrorData(data: unknown): data is AppErrorData {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    typeof (data as AppErrorData).code === "string" &&
+    typeof (data as AppErrorData).message === "string"
+  );
+}
+
+/**
+ * Normalizes anything thrown by a Convex call into `{ code, message }`.
+ * Never surfaces the underlying message for non-app errors — on prod it is
+ * redacted to "Server Error" anyway, and on dev it may leak internals.
+ */
+export function getAppError(error: unknown): ClientError {
+  if (!(error instanceof ConvexError)) return UNKNOWN;
+  const data: unknown = error.data;
+  if (isAppErrorData(data)) return { code: data.code, message: data.message };
+  // Shape thrown by @convex-dev/rate-limiter with `throws: true`.
+  if (
+    typeof data === "object" &&
+    data !== null &&
+    (data as { kind?: unknown }).kind === "RateLimited"
+  )
+    return RATE_LIMITED;
+  return UNKNOWN;
+}


### PR DESCRIPTION
## Summary

Every user-facing failure in `convex/` was `throw new Error("...")`. Convex redacts plain `Error` messages on prod deployments, so the client only sees "Server Error" — and no UI site toasted anything anyway (all 10 `tryCatch` sites were Sentry + `return`). This moves user-facing throws to `ConvexError` via one helper, adds a client-side normalizer, and wires the CLAUDE.md toast invariant at every call site. Mechanical shape change — no condition that throws, and no guard order, changed.

Closes #122

## Changes

- `convex/utils/errors.ts` (new): `ERROR_CODES` (`as const`), `ErrorCode`, `ApiErrorData`, `apiError(code, message)` → `ConvexError<{ code, message }>`.
- `convex/{players,sessions,rounds,selections}.ts`, `convex/utils/auth.ts`: every `throw new Error(msg)` → `throw apiError(CODE, msg)`. **Message text unchanged.** Validation failures use `VALIDATION` with the validator's message.
- Left as plain `Error`, each with an `// internal:` comment: `convex/test/seed.ts`, `convex/reset.ts`, `convex/utils/dates.ts`, and the four third-party `${response.status}` throws in `tmdb/igdb/openlibrary.ts`.
- `src/utils/api-error.ts` (new): `getApiError(unknown)` → `{ code, message }`. App `ConvexError` passes through; the rate-limiter's `ConvexError` (`data.kind === "RateLimited"`) → `RATE_LIMITED` / "Slow down and try again"; everything else → `UNKNOWN` / "Something went wrong" — never the underlying message.
- UI (`lobby.tsx` ×2, `topic.tsx` ×2, `round.tsx` ×3, `sidebar-content.tsx` ×3): `Sentry.captureException(error)` → `toast.show({ message: getApiError(error).message, variant: "error" })` → `return`. `sidebar-content` leave/end still navigates home on error, now with a toast first.
- `topic.tsx`: `ALREADY_JOINED` branch is `getApiError(error).code === "ALREADY_JOINED"` instead of matching `error.message`.
- Tests: `src/shared/__tests__/errors.test.ts` (helper shape) and `api-error.test.ts` (pass-through, rate-limit mapping, non-leaking fallback for plain `Error` / string / `undefined` / unrecognized `ConvexError` data).

## Verification

- `bun run check:format && bun run check:lint && bun run check:types && bun test` — green (47 tests, 5 new).
- `grep -rn "throw new Error" convex/` → only the commented internal sites.
- Not verified by me: the on-prod toast. **Manual check for Ryan after deploy** (`IS_PROD` set, #71): as a non-host, kick someone → toast "Only the host can kick players", not "Something went wrong".
- e2e runs in CI; no test IDs or flows changed, only error-path toasts added.

## Notes for reviewer

- Naming: ticket said `appError`/`AppErrorData`/`app-error.ts`; shipped as `apiError`/`ApiErrorData`/`api-error.ts` per review discussion (commit `91b1b48`).
- `convex-test` is not a dependency, so the changed Convex functions have no `convex-test` coverage (same catch-22 as #121 — adding it is a deps change). The error helpers are pure and unit-tested; the throw sites are a mechanical rename. Human call.
- Also carries the `CLAUDE.md` "no Claude-Session trailers" rule (commit `0e3a4ac`) — Ryan asked for it to ride along.
- Helper lives in `convex/utils/errors.ts` (not `convex/errors.ts` as the ticket said) — the `convex/utils/*` path alias already exists for `src/` imports and `.claude/rules/convex.md` puts shared helpers there. Avoided a `tsconfig.json`/Vite alias change.
- `getApiError` checks the rate-limiter's data shape inline rather than importing `isRateLimitError` from `@convex-dev/rate-limiter` into the browser bundle (that entry pulls in `convex/server`). Shape is `{ kind: "RateLimited", name, retryAfter }`; the test builds it explicitly.
- `RATE_LIMITED` toast wording is a placeholder.
- **Rule-text edits for you to apply** (forbidden zone for me to touch):

  `.claude/rules/convex.md`, "Errors and queries", first bullet:

  ```
  - Fail with `throw apiError("<CODE>", "<Sentence case message>")` from `convex/utils/errors` immediately after the guard, one guard per line. Plain `Error` only at internal sites (internalMutation, test seeding, third-party fetch), with an `// internal:` comment. Never return error objects.
  ```

  `CLAUDE.md`, "Error handling in UI" invariant:

  ```
  - **Error handling in UI**: wrap every awaited Convex mutation/action call in `tryCatch` from `utils/try-catch`; on error, `Sentry.captureException(error)`, surface `getApiError(error).message` from `utils/api-error` via `useToast`, then early-return. Branch on `getApiError(error).code`, never on message text. Navigate/update state only on success. Never bare try/catch, never fire-and-forget mutations.
  ```

- Follow-up already filed: #123 (`requireSessionMember` returns `null`; queries return `[]` for non-members).
