### PR TITLE
ci(seery/harden-actions): pin actions to SHAs, gate @claude to members

### DIFF
--- a/.github/workflows/agent-queue.yml
+++ b/.github/workflows/agent-queue.yml
@@ -78,11 +78,11 @@ jobs:
     outputs:
       stats: ${{ steps.stats.outputs.stats }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@8251c103ac8c1d761882c86aba1412c7f583c844 # v1
         id: claude
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,15 +26,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 
       - name: Cache bun dependencies
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
@@ -64,15 +64,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 
       - name: Cache bun dependencies
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
@@ -83,7 +83,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}
@@ -178,7 +178,7 @@ jobs:
 
       - name: Upload test artifacts
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-report
           path: |

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -30,14 +30,14 @@ jobs:
       issues: read
       id-token: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
           # issue_comment fires on the default branch; check out the PR head
           # so the reviewer reads the files under review.
           ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/head', github.event.issue.number) || '' }}
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@8251c103ac8c1d761882c86aba1412c7f583c844 # v1
         id: claude
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -8,11 +8,11 @@ on:
 
 jobs:
   claude:
-    # Interactive @claude — the resolve loop. Human actors only (default):
-    # Ryan comments "@claude fix the review comments" on a PR and the
-    # implementer picks the findings up on that branch. "@claude review" is
-    # the reviewer's manual trigger (claude-review.yml), not ours.
-    if: contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude review')
+    # "@claude review" belongs to claude-review.yml; members only — public repo.
+    if: >-
+      contains(github.event.comment.body, '@claude') &&
+      !contains(github.event.comment.body, '@claude review') &&
+      contains(fromJSON('["OWNER", "MEMBER"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
@@ -22,16 +22,17 @@ jobs:
       id-token: write
       actions: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@8251c103ac8c1d761882c86aba1412c7f583c844 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
             --model claude-sonnet-5
             --max-turns 60
+            --allowedTools "Bash(git:*),Bash(gh:*),Bash(bun:*),Bash(bunx:*),Read,Edit,Write,Glob,Grep,Agent"
 
       - name: Dump execution output on failure
         if: failure()


### PR DESCRIPTION
## Summary

Supply-chain hardening from the #125 discussion: every action pinned to a full commit SHA, and the interactive `@claude` workflow gated to org members with an explicit tool allowlist. The `v1` tag of claude-code-action moved between Saturday's runs and today — pins make that a non-event.

Companion settings changes already applied via API (not in this diff): Actions restricted to an allowlist (GitHub-owned + `anthropics/claude-code-action` + `oven-sh/setup-bun`), default `GITHUB_TOKEN` read-only, workflow PR-approval off.

## Changes

- All `uses:` in `ci.yml`, `claude.yml`, `claude-review.yml`, `agent-queue.yml` pinned to full SHAs with `# vN` comments (Dependabot keeps these current).
- `claude.yml`: `author_association` gate (OWNER/MEMBER) enforced in the workflow `if`, ahead of the action's own actor check; `--allowedTools` restricted to git/gh/bun + file tools.

## Verification

- `bun run check:format` clean; `bunx tsc --noEmit` clean via pre-commit hook. actionlint not installed locally — workflow YAML unchanged structurally beyond the `if` expression.
- Each SHA resolved from its tag via `gh api repos/<action>/commits/<tag>` today.
- Not verified live: an `@claude` comment from a non-member being skipped (needs a non-member account).

## Notes for reviewer

- The Claude Review run on this PR will show green-but-skipped in seconds — claude-code-action refuses to run when the workflow file differs from main (the blind spot documented in #125). Expected.
- After merge, flip **Settings → Actions → Require SHA pinning** (left off until the pinned files are on main, or every workflow would fail).
- `claude-review.yml`, `claude.yml`, `agent-queue.yml` are pinned here but slated for deletion in #133 — cheap insurance while they live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
