### PR TITLE
chore(seery/pipeline): ignore .pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ yarn-error.*
 
 
 .claude/settings.local.json
+
+.pipeline/


### PR DESCRIPTION
## Summary
Ignore the local `.pipeline/` directory (private pipeline tooling per the #125/#133 direction).

## Changes
- `.gitignore`: add `.pipeline/`

## Verification
`git status` shows the directory ignored; pre-commit `tsc` clean.

## Notes for reviewer
One line; contents of the directory intentionally undocumented here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)