### PR TITLE
fix(agent/game-guards): guard game mutations with membership, host and state checks

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,7 @@
         "@types/react": "19.2.18",
         "@types/react-dom": "19.2.5",
         "@vitejs/plugin-react": "6.1.1",
+        "convex-test": "0.0.56",
         "husky": "9.1.7",
         "oxfmt": "0.65.0",
         "oxlint": "1.80.0",
@@ -428,6 +429,8 @@
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "convex": ["convex@1.45.0", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.21.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "@clerk/react": "^6.4.3", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "@clerk/react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-AV3B56Ptu/14d76g3urBJ50dwpiZa6uJaLT84OWox5aCwZIJiuAamdjv3lLHDzs8vv5kC31anEZohhUe3qJ2bA=="],
+
+    "convex-test": ["convex-test@0.0.56", "", { "peerDependencies": { "convex": "^1.43.0" } }, "sha512-dLYXlQjKFoGqvjAmPzyLgb2HsYI7iLo1iuNTU2DZmSrMRLWosYk94erjSU67GG5ovfP6+MjX8RJO+ebhmL6QYA=="],
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 

--- a/convex/__tests__/harness.setup.ts
+++ b/convex/__tests__/harness.setup.ts
@@ -1,0 +1,110 @@
+import { Glob } from "bun";
+
+import { convexTest } from "convex-test";
+
+import type { Id } from "../_generated/dataModel";
+import { MAX_PLAYERS, MAX_ROUNDS, SessionStatus } from "../constants";
+import schema from "../schema";
+
+// `convex-test` normally discovers modules via Vite's `import.meta.glob`, which
+// Bun does not implement — build the equivalent `path -> loader` map by hand.
+// The file is named `*.setup.ts` so `convex deploy` skips it (two dots).
+const CONVEX_ROOT = new URL("../", import.meta.url).pathname;
+const RATE_LIMITER_ROOT = new URL(
+  "../../node_modules/@convex-dev/rate-limiter/src/component/",
+  import.meta.url,
+).pathname;
+
+function moduleMap(root: string) {
+  const modules: Record<string, () => Promise<unknown>> = {};
+
+  for (const path of new Glob("**/*.{ts,js}").scanSync({ cwd: root })) {
+    if (path.endsWith(".d.ts") || path.includes(".test.") || path.startsWith("__tests__/"))
+      continue;
+    modules[`./${path}`] = () => import(root + path);
+  }
+
+  return modules;
+}
+
+/** A `convex-test` instance with the rate limiter component registered. */
+export async function setupTest() {
+  const t = convexTest(schema, moduleMap(CONVEX_ROOT));
+  const rateLimiterSchema = (await import(`${RATE_LIMITER_ROOT}schema.ts`)).default;
+
+  t.registerComponent("rateLimiter", rateLimiterSchema, moduleMap(RATE_LIMITER_ROOT));
+
+  return t;
+}
+
+export const HOST_UID = "host-uid";
+export const MEMBER_UID = "member-uid";
+export const OUTSIDER_UID = "outsider-uid";
+
+type TestConvex = Awaited<ReturnType<typeof setupTest>>;
+
+export type SeededGame = {
+  sessionId: Id<"sessions">;
+  roundIds: Id<"rounds">[];
+};
+
+/**
+ * An ACTIVE session with a host, one other member, and `MAX_ROUNDS` rounds
+ * where the highest-numbered round is `open` (matching `startSession`).
+ */
+export async function seedActiveGame(t: TestConvex): Promise<SeededGame> {
+  return await t.run(async (ctx) => {
+    const sessionId = await ctx.db.insert("sessions", {
+      topic: "games",
+      year: 2025,
+      maxRounds: MAX_ROUNDS,
+      maxPlayers: MAX_PLAYERS,
+      playerCount: 2,
+      activeRoundNumber: MAX_ROUNDS,
+      status: SessionStatus.ACTIVE,
+    });
+
+    await ctx.db.insert("players", {
+      sessionId,
+      uid: HOST_UID,
+      name: "Host",
+      avatar: "🐙",
+      isHost: true,
+    });
+    await ctx.db.insert("players", {
+      sessionId,
+      uid: MEMBER_UID,
+      name: "Member",
+      avatar: "🦊",
+      isHost: false,
+    });
+
+    const roundIds: Id<"rounds">[] = [];
+
+    for (let number = 1; number <= MAX_ROUNDS; number++) {
+      const isActive = number === MAX_ROUNDS;
+      roundIds.push(
+        await ctx.db.insert("rounds", {
+          sessionId,
+          number,
+          state: isActive ? "open" : "pending",
+          weight: MAX_ROUNDS + 1 - number,
+          selectionsComplete: 0,
+          startedAt: isActive ? Date.now() : null,
+          closedAt: null,
+        }),
+      );
+    }
+
+    return { sessionId, roundIds };
+  });
+}
+
+export const OPTION = {
+  id: 1234,
+  name: "Blue Prince",
+  cover: "cover.jpg",
+  rating: 90,
+  first_release_date: 1_744_000_000,
+  summary: "A house of many doors.",
+};

--- a/convex/__tests__/rounds.test.ts
+++ b/convex/__tests__/rounds.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "bun:test";
+
+import { api } from "../_generated/api";
+import { MAX_ROUNDS } from "../constants";
+import { HOST_UID, MEMBER_UID, OUTSIDER_UID, seedActiveGame, setupTest } from "./harness.setup";
+
+describe("getRound", () => {
+  it("throws for a non-member", async () => {
+    const t = await setupTest();
+    const { sessionId } = await seedActiveGame(t);
+
+    await expect(
+      t
+        .withIdentity({ subject: OUTSIDER_UID })
+        .query(api.rounds.getRound, { sessionId, number: MAX_ROUNDS }),
+    ).rejects.toThrow(/NOT_MEMBER/);
+  });
+
+  it("returns the round for a member", async () => {
+    const t = await setupTest();
+    const { sessionId } = await seedActiveGame(t);
+
+    const round = await t
+      .withIdentity({ subject: MEMBER_UID })
+      .query(api.rounds.getRound, { sessionId, number: MAX_ROUNDS });
+
+    expect(round?.number).toBe(MAX_ROUNDS);
+    expect(round?.state).toBe("open");
+  });
+});
+
+describe("advanceRound", () => {
+  it("throws when unauthenticated", async () => {
+    const t = await setupTest();
+    const { sessionId } = await seedActiveGame(t);
+
+    await expect(
+      t.mutation(api.rounds.advanceRound, { sessionId, currentRoundNumber: MAX_ROUNDS }),
+    ).rejects.toThrow(/UNAUTHENTICATED/);
+  });
+
+  it("throws for a non-member and leaves the round untouched", async () => {
+    const t = await setupTest();
+    const { sessionId } = await seedActiveGame(t);
+
+    await expect(
+      t
+        .withIdentity({ subject: OUTSIDER_UID })
+        .mutation(api.rounds.advanceRound, { sessionId, currentRoundNumber: MAX_ROUNDS }),
+    ).rejects.toThrow(/NOT_MEMBER/);
+
+    const session = await t.run(async (ctx) => await ctx.db.get(sessionId));
+    expect(session?.activeRoundNumber).toBe(MAX_ROUNDS);
+  });
+
+  it("throws for a member who is not the host and leaves the round untouched", async () => {
+    const t = await setupTest();
+    const { sessionId, roundIds } = await seedActiveGame(t);
+
+    await expect(
+      t
+        .withIdentity({ subject: MEMBER_UID })
+        .mutation(api.rounds.advanceRound, { sessionId, currentRoundNumber: MAX_ROUNDS }),
+    ).rejects.toThrow(/NOT_HOST/);
+
+    const round = await t.run(async (ctx) => await ctx.db.get(roundIds[MAX_ROUNDS - 1]));
+    expect(round?.state).toBe("open");
+  });
+
+  it("lets the host advance an empty round to the next one", async () => {
+    const t = await setupTest();
+    const { sessionId, roundIds } = await seedActiveGame(t);
+
+    const result = await t
+      .withIdentity({ subject: HOST_UID })
+      .mutation(api.rounds.advanceRound, { sessionId, currentRoundNumber: MAX_ROUNDS });
+
+    expect(result).toEqual({ hasNextRound: true });
+
+    const { closed, next, session } = await t.run(async (ctx) => ({
+      closed: await ctx.db.get(roundIds[MAX_ROUNDS - 1]),
+      next: await ctx.db.get(roundIds[MAX_ROUNDS - 2]),
+      session: await ctx.db.get(sessionId),
+    }));
+
+    expect(closed?.state).toBe("closed");
+    expect(next?.state).toBe("open");
+    expect(session?.activeRoundNumber).toBe(MAX_ROUNDS - 1);
+  });
+
+  it("throws when the host re-advances an already closed round", async () => {
+    const t = await setupTest();
+    const { sessionId, roundIds } = await seedActiveGame(t);
+    const host = t.withIdentity({ subject: HOST_UID });
+
+    await host.mutation(api.rounds.advanceRound, { sessionId, currentRoundNumber: MAX_ROUNDS });
+
+    await expect(
+      host.mutation(api.rounds.advanceRound, { sessionId, currentRoundNumber: MAX_ROUNDS }),
+    ).rejects.toThrow(/WRONG_STATE/);
+
+    const { closed, next, session } = await t.run(async (ctx) => ({
+      closed: await ctx.db.get(roundIds[MAX_ROUNDS - 1]),
+      next: await ctx.db.get(roundIds[MAX_ROUNDS - 2]),
+      session: await ctx.db.get(sessionId),
+    }));
+
+    expect(closed?.state).toBe("closed");
+    expect(next?.state).toBe("open");
+    expect(session?.activeRoundNumber).toBe(MAX_ROUNDS - 1);
+  });
+
+  it("throws when the host advances a round that has not started", async () => {
+    const t = await setupTest();
+    const { sessionId } = await seedActiveGame(t);
+
+    await expect(
+      t
+        .withIdentity({ subject: HOST_UID })
+        .mutation(api.rounds.advanceRound, { sessionId, currentRoundNumber: 1 }),
+    ).rejects.toThrow(/WRONG_STATE/);
+  });
+});

--- a/convex/__tests__/selections.test.ts
+++ b/convex/__tests__/selections.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "bun:test";
+
+import { api } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import { MAX_ROUNDS } from "../constants";
+import {
+  MEMBER_UID,
+  OPTION,
+  OUTSIDER_UID,
+  seedActiveGame,
+  setupTest,
+  type SeededGame,
+} from "./harness.setup";
+
+type TestConvex = Awaited<ReturnType<typeof setupTest>>;
+
+async function seedSelection(t: TestConvex, game: SeededGame, uid: string) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("selections", {
+      sessionId: game.sessionId,
+      roundId: game.roundIds[MAX_ROUNDS - 1],
+      uid,
+      pick: { id: String(OPTION.id), name: OPTION.name },
+      points: 1,
+      roundNumber: MAX_ROUNDS,
+      savedAt: Date.now(),
+    });
+  });
+}
+
+async function setRoundState(
+  t: TestConvex,
+  roundId: Id<"rounds">,
+  state: "pending" | "open" | "closed" | "revealing",
+) {
+  await t.run(async (ctx) => await ctx.db.patch(roundId, { state }));
+}
+
+async function pickNames(t: TestConvex, sessionId: Id<"sessions">) {
+  return await t.run(async (ctx) => {
+    const selections = await ctx.db
+      .query("selections")
+      .withIndex("by_session", (q) => q.eq("sessionId", sessionId))
+      .collect();
+    return selections.map((s) => s.pick.name);
+  });
+}
+
+describe("saveSelection", () => {
+  it("throws when unauthenticated", async () => {
+    const t = await setupTest();
+    const { sessionId } = await seedActiveGame(t);
+
+    await expect(
+      t.mutation(api.selections.saveSelection, {
+        sessionId,
+        roundNumber: MAX_ROUNDS,
+        option: OPTION,
+      }),
+    ).rejects.toThrow(/UNAUTHENTICATED/);
+  });
+
+  it("throws for a non-member and writes nothing", async () => {
+    const t = await setupTest();
+    const { sessionId } = await seedActiveGame(t);
+
+    await expect(
+      t.withIdentity({ subject: OUTSIDER_UID }).mutation(api.selections.saveSelection, {
+        sessionId,
+        roundNumber: MAX_ROUNDS,
+        option: OPTION,
+      }),
+    ).rejects.toThrow(/NOT_MEMBER/);
+
+    expect(await pickNames(t, sessionId)).toEqual([]);
+  });
+
+  it("throws when the round is not open", async () => {
+    const t = await setupTest();
+    const game = await seedActiveGame(t);
+    await setRoundState(t, game.roundIds[MAX_ROUNDS - 1], "revealing");
+
+    await expect(
+      t.withIdentity({ subject: MEMBER_UID }).mutation(api.selections.saveSelection, {
+        sessionId: game.sessionId,
+        roundNumber: MAX_ROUNDS,
+        option: OPTION,
+      }),
+    ).rejects.toThrow(/WRONG_STATE/);
+
+    expect(await pickNames(t, game.sessionId)).toEqual([]);
+  });
+
+  it("saves a pick for a member on an open round", async () => {
+    const t = await setupTest();
+    const { sessionId } = await seedActiveGame(t);
+
+    await t.withIdentity({ subject: MEMBER_UID }).mutation(api.selections.saveSelection, {
+      sessionId,
+      roundNumber: MAX_ROUNDS,
+      option: OPTION,
+    });
+
+    expect(await pickNames(t, sessionId)).toEqual(["Blue Prince"]);
+  });
+});
+
+describe("editSelection", () => {
+  it("throws when unauthenticated", async () => {
+    const t = await setupTest();
+    const game = await seedActiveGame(t);
+    await seedSelection(t, game, MEMBER_UID);
+
+    await expect(
+      t.mutation(api.selections.editSelection, {
+        sessionId: game.sessionId,
+        roundNumber: MAX_ROUNDS,
+        option: { ...OPTION, name: "Overwritten" },
+      }),
+    ).rejects.toThrow(/UNAUTHENTICATED/);
+  });
+
+  it("throws for a non-member and leaves the pick intact", async () => {
+    const t = await setupTest();
+    const game = await seedActiveGame(t);
+    await seedSelection(t, game, MEMBER_UID);
+
+    await expect(
+      t.withIdentity({ subject: OUTSIDER_UID }).mutation(api.selections.editSelection, {
+        sessionId: game.sessionId,
+        roundNumber: MAX_ROUNDS,
+        option: { ...OPTION, name: "Overwritten" },
+      }),
+    ).rejects.toThrow(/NOT_MEMBER/);
+
+    expect(await pickNames(t, game.sessionId)).toEqual(["Blue Prince"]);
+  });
+
+  it("throws once the round has closed and leaves the pick intact", async () => {
+    const t = await setupTest();
+    const game = await seedActiveGame(t);
+    await seedSelection(t, game, MEMBER_UID);
+    await setRoundState(t, game.roundIds[MAX_ROUNDS - 1], "closed");
+
+    await expect(
+      t.withIdentity({ subject: MEMBER_UID }).mutation(api.selections.editSelection, {
+        sessionId: game.sessionId,
+        roundNumber: MAX_ROUNDS,
+        option: { ...OPTION, name: "Overwritten" },
+      }),
+    ).rejects.toThrow(/WRONG_STATE/);
+
+    expect(await pickNames(t, game.sessionId)).toEqual(["Blue Prince"]);
+  });
+
+  it("throws while the round is revealing and leaves the pick intact", async () => {
+    const t = await setupTest();
+    const game = await seedActiveGame(t);
+    await seedSelection(t, game, MEMBER_UID);
+    await setRoundState(t, game.roundIds[MAX_ROUNDS - 1], "revealing");
+
+    await expect(
+      t.withIdentity({ subject: MEMBER_UID }).mutation(api.selections.editSelection, {
+        sessionId: game.sessionId,
+        roundNumber: MAX_ROUNDS,
+        option: { ...OPTION, name: "Overwritten" },
+      }),
+    ).rejects.toThrow(/WRONG_STATE/);
+
+    expect(await pickNames(t, game.sessionId)).toEqual(["Blue Prince"]);
+  });
+
+  it("rewrites the pick for a member while the round is open", async () => {
+    const t = await setupTest();
+    const game = await seedActiveGame(t);
+    await seedSelection(t, game, MEMBER_UID);
+
+    await t.withIdentity({ subject: MEMBER_UID }).mutation(api.selections.editSelection, {
+      sessionId: game.sessionId,
+      roundNumber: MAX_ROUNDS,
+      option: { ...OPTION, name: "Overwritten" },
+    });
+
+    expect(await pickNames(t, game.sessionId)).toEqual(["Overwritten"]);
+  });
+});
+
+describe("selection queries", () => {
+  it("throw for a non-member", async () => {
+    const t = await setupTest();
+    const game = await seedActiveGame(t);
+    await seedSelection(t, game, MEMBER_UID);
+
+    const asOutsider = t.withIdentity({ subject: OUTSIDER_UID });
+    const { sessionId } = game;
+
+    await expect(
+      asOutsider.query(api.selections.getSelections, { sessionId, number: MAX_ROUNDS }),
+    ).rejects.toThrow(/NOT_MEMBER/);
+    await expect(asOutsider.query(api.selections.getMySelections, { sessionId })).rejects.toThrow(
+      /NOT_MEMBER/,
+    );
+    await expect(asOutsider.query(api.selections.getResults, { sessionId })).rejects.toThrow(
+      /NOT_MEMBER/,
+    );
+  });
+
+  it("return data for a member", async () => {
+    const t = await setupTest();
+    const game = await seedActiveGame(t);
+    await seedSelection(t, game, MEMBER_UID);
+
+    const asMember = t.withIdentity({ subject: MEMBER_UID });
+    const { sessionId } = game;
+
+    expect(
+      await asMember.query(api.selections.getSelections, { sessionId, number: MAX_ROUNDS }),
+    ).toHaveLength(1);
+    expect(await asMember.query(api.selections.getMySelections, { sessionId })).toHaveLength(1);
+    expect(await asMember.query(api.selections.getResults, { sessionId })).toEqual([
+      {
+        pick: { id: String(OPTION.id), name: OPTION.name },
+        totalPoints: 1,
+        votes: [{ playerName: "Member", playerAvatar: "🦊", points: 1 }],
+      },
+    ]);
+  });
+});

--- a/convex/ratelimits.ts
+++ b/convex/ratelimits.ts
@@ -6,4 +6,6 @@ export const rateLimiter = new RateLimiter(components.rateLimiter, {
   createSession: { kind: "token bucket", rate: 5, period: MINUTE },
   joinSession: { kind: "token bucket", rate: 10, period: MINUTE },
   saveSelection: { kind: "token bucket", rate: 20, period: MINUTE },
+  editSelection: { kind: "token bucket", rate: 20, period: MINUTE },
+  advanceRound: { kind: "token bucket", rate: 30, period: MINUTE },
 });

--- a/convex/rounds.ts
+++ b/convex/rounds.ts
@@ -4,6 +4,7 @@ import { internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import type { MutationCtx } from "./_generated/server";
 import { internalMutation, mutation, query } from "./_generated/server";
+import { rateLimiter } from "./ratelimits";
 import { requireSessionMember } from "./utils/auth";
 import { apiError } from "./utils/errors";
 import { getRoundByNumber } from "./utils/rounds";
@@ -11,7 +12,7 @@ import { getRoundByNumber } from "./utils/rounds";
 export const getRound = query({
   args: { sessionId: v.id("sessions"), number: v.number() },
   handler: async (ctx, { sessionId, number }) => {
-    if (!(await requireSessionMember(ctx, sessionId))) return null;
+    await requireSessionMember(ctx, sessionId);
 
     const round = await ctx.db
       .query("rounds")
@@ -29,8 +30,17 @@ export const advanceRound = mutation({
     currentRoundNumber: v.number(),
   },
   handler: async (ctx, { sessionId, currentRoundNumber }) => {
-    const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw apiError("UNAUTHENTICATED", "Unauthenticated");
+    const identity = await requireSessionMember(ctx, sessionId);
+    const uid = identity.subject;
+
+    const host = await ctx.db
+      .query("players")
+      .withIndex("by_session_uid", (q) => q.eq("sessionId", sessionId).eq("uid", uid))
+      .unique();
+
+    if (!host?.isHost) throw apiError("NOT_HOST", "Only the host can advance the round");
+
+    await rateLimiter.limit(ctx, "advanceRound", { key: uid, throws: true });
 
     const currentRound = await ctx.db
       .query("rounds")
@@ -39,6 +49,9 @@ export const advanceRound = mutation({
       .unique();
 
     if (!currentRound) throw apiError("NOT_FOUND", "Round not found");
+    if (currentRound.state !== "open" && currentRound.state !== "revealing") {
+      throw apiError("WRONG_STATE", "Round is not in play");
+    }
 
     if (currentRound.state === "revealing") {
       if (currentRound.revealJobId) {

--- a/convex/selections.ts
+++ b/convex/selections.ts
@@ -13,7 +13,7 @@ import { getRoundByNumber } from "./utils/rounds";
 export const getSelections = query({
   args: { sessionId: v.id("sessions"), number: v.number() },
   handler: async (ctx, { sessionId, number }) => {
-    if (!(await requireSessionMember(ctx, sessionId))) return [];
+    await requireSessionMember(ctx, sessionId);
 
     const round = await getRoundByNumber(ctx.db, sessionId, number);
     if (!round) return [];
@@ -29,7 +29,6 @@ export const getMySelections = query({
   args: { sessionId: v.id("sessions") },
   handler: async (ctx, { sessionId }) => {
     const identity = await requireSessionMember(ctx, sessionId);
-    if (!identity) return [];
     const uid = identity.subject;
 
     const rounds = await ctx.db
@@ -68,8 +67,7 @@ export const saveSelection = mutation({
     option: optionArg,
   },
   handler: async (ctx, { sessionId, roundNumber, option }) => {
-    const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw apiError("UNAUTHENTICATED", "Unauthenticated");
+    const identity = await requireSessionMember(ctx, sessionId);
     const uid = identity.subject;
 
     await rateLimiter.limit(ctx, "saveSelection", { key: uid, throws: true });
@@ -129,12 +127,14 @@ export const editSelection = mutation({
     option: optionArg,
   },
   handler: async (ctx, { sessionId, roundNumber, option }) => {
-    const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw apiError("UNAUTHENTICATED", "Unauthenticated");
+    const identity = await requireSessionMember(ctx, sessionId);
     const uid = identity.subject;
+
+    await rateLimiter.limit(ctx, "editSelection", { key: uid, throws: true });
 
     const round = await getRoundByNumber(ctx.db, sessionId, roundNumber);
     if (!round) throw apiError("NOT_FOUND", "Round not found");
+    if (round.state !== "open") throw apiError("WRONG_STATE", "Round is not open");
 
     const existing = await ctx.db
       .query("selections")
@@ -153,7 +153,7 @@ export const editSelection = mutation({
 export const getResults = query({
   args: { sessionId: v.id("sessions") },
   handler: async (ctx, { sessionId }) => {
-    if (!(await requireSessionMember(ctx, sessionId))) return [];
+    await requireSessionMember(ctx, sessionId);
 
     const [allSelections, players] = await Promise.all([
       ctx.db

--- a/convex/utils/auth.ts
+++ b/convex/utils/auth.ts
@@ -11,7 +11,7 @@ export async function requireSessionMember(ctx: QueryCtx, sessionId: Id<"session
     .withIndex("by_session_uid", (q) => q.eq("sessionId", sessionId).eq("uid", identity.subject))
     .unique();
 
-  if (!player) return null;
+  if (!player) throw apiError("NOT_MEMBER", "Player not in session");
 
   return identity;
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.5",
     "@vitejs/plugin-react": "6.1.1",
+    "convex-test": "0.0.56",
     "husky": "9.1.7",
     "oxfmt": "0.65.0",
     "oxlint": "1.80.0",

--- a/playwright/game/multiplayer.e2e.ts
+++ b/playwright/game/multiplayer.e2e.ts
@@ -46,6 +46,14 @@ test("multiplayer: host flow with advance-round", async ({ page }) => {
   await page.getByTestId("submit-pick").click();
   await expect(page.getByTestId("submit-pick")).toBeDisabled();
 
+  // Round 10 is still open (others have not picked) — the pick can be edited
+  await page.getByTestId("edit-pick").click();
+  await expect(page.getByTestId("cancel-edit")).toBeVisible();
+  await expect(page.getByTestId("submit-pick")).toBeEnabled();
+  await page.getByTestId("submit-pick").click();
+  await expect(page.getByTestId("cancel-edit")).toHaveCount(0);
+  await expect(page.getByTestId("submit-pick")).toContainText("Enter");
+
   await makeSelection({ sessionId, uid: player2Uid, roundNumber: 10, pickName: "Elden Ring" });
   await makeSelection({ sessionId, uid: player3Uid, roundNumber: 10, pickName: "Elden Ring" });
 

--- a/playwright/game/single-player.e2e.ts
+++ b/playwright/game/single-player.e2e.ts
@@ -37,12 +37,10 @@ test("single-player: full game", async ({ page }) => {
   await expect(page.getByTestId("reveal-skip")).toBeVisible();
   await page.getByTestId("reveal-skip").click();
 
-  // Edit pick after reveal
-  await page.getByTestId("edit-pick").click();
-  await expect(page.getByTestId("cancel-edit")).toBeVisible();
-  await expect(page.getByTestId("submit-pick")).toBeEnabled();
-  await page.getByTestId("submit-pick").click();
-  await expect(page.getByTestId("submit-pick")).toContainText("Enter");
+  // Round 10 is closed — its pick is locked, so no Edit affordance
+  await expect(page.getByText("Round 9")).toBeVisible();
+  await expect(page.getByTestId("round-list")).toBeVisible();
+  await expect(page.getByTestId("edit-pick")).toHaveCount(0);
 
   // Rounds 9–1
   const letters = ["c", "d", "e", "f", "g", "h", "m", "p", "s"];

--- a/src/components/lists/picks.tsx
+++ b/src/components/lists/picks.tsx
@@ -63,16 +63,22 @@ interface Props {
   data: PickItem[];
   testID?: string;
   onEdit?: (item: MySelection) => void;
+  /** Only this round's pick gets an Edit button — closed rounds are locked server-side. */
+  editableRoundNumber?: number;
 }
 
-export function Picks({ data, testID, onEdit }: Props) {
+export function Picks({ data, testID, onEdit, editableRoundNumber }: Props) {
   return (
     <div data-testid={testID} className="flex flex-1 flex-col gap-sm">
       {data.map((item, index) =>
         "totalPoints" in item ? (
           <RankedRow key={item.pick.id} item={item} rank={index + 1} />
         ) : (
-          <SelectionRow key={item.pick.id} item={item} onEdit={onEdit} />
+          <SelectionRow
+            key={item.pick.id}
+            item={item}
+            onEdit={item.roundNumber === editableRoundNumber ? onEdit : undefined}
+          />
         ),
       )}
     </div>

--- a/src/components/sidebar/sidebar-content.tsx
+++ b/src/components/sidebar/sidebar-content.tsx
@@ -56,6 +56,11 @@ export function SidebarContent({ sessionId, topic, year, handleClose }: SidebarC
   };
 
   const onLeaveGame = async () => {
+    // Navigate first: leaving deletes our player row, and the game screen's
+    // queries throw NOT_MEMBER the moment it does — which the root
+    // ErrorBoundary would turn into DisplayError instead of home.
+    await navigate({ to: "/", replace: true });
+
     const mutation = isHost ? endSession({ sessionId }) : leaveSession({ sessionId });
     const { error } = await tryCatch(mutation);
     if (error) {
@@ -63,7 +68,6 @@ export function SidebarContent({ sessionId, topic, year, handleClose }: SidebarC
       Sentry.captureException(error);
       toast.show({ message: getApiError(error).message, variant: "error" });
     }
-    navigate({ to: "/", replace: true });
   };
 
   const onKick = async (uid: string) => {

--- a/src/screens/round/round.tsx
+++ b/src/screens/round/round.tsx
@@ -1,6 +1,6 @@
 import * as Sentry from "@sentry/react";
 import { useNavigate } from "@tanstack/react-router";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { Autocomplete } from "components/autocomplete";
 import { Button } from "components/button";
@@ -58,6 +58,13 @@ export function Round({ sessionId, topic, year }: Props) {
   const [selectedOption, setSelectedOption] = useState<Option | null>(null);
 
   const availableOptions = useAvailableOptions(options, mySelections, editingRound);
+
+  // Editing only survives while its round is open, so drop it when the round advances.
+  useEffect(() => {
+    setEditingRound(null);
+    setInputValue("");
+    setSelectedOption(null);
+  }, [session?.activeRoundNumber]);
 
   if (isLoading) return <Loading />;
   if (!session) return <DisplayError />;
@@ -153,7 +160,12 @@ export function Round({ sessionId, topic, year }: Props) {
 
   return (
     <Container>
-      <Picks testID="round-list" data={mySelections} onEdit={onEdit} />
+      <Picks
+        testID="round-list"
+        data={mySelections}
+        onEdit={onEdit}
+        editableRoundNumber={round?.state === "open" ? session.activeRoundNumber : undefined}
+      />
       <div className="mt-auto flex flex-col gap-md pt-md">
         <Autocomplete
           testID="pick-input"

--- a/src/screens/round/round.tsx
+++ b/src/screens/round/round.tsx
@@ -1,6 +1,6 @@
 import * as Sentry from "@sentry/react";
 import { useNavigate } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import { Autocomplete } from "components/autocomplete";
 import { Button } from "components/button";
@@ -57,14 +57,12 @@ export function Round({ sessionId, topic, year }: Props) {
   const [editingRound, setEditingRound] = useState<number | null>(null);
   const [selectedOption, setSelectedOption] = useState<Option | null>(null);
 
-  const availableOptions = useAvailableOptions(options, mySelections, editingRound);
+  // The screen stays mounted across rounds, so an edit begun in a round that has
+  // since closed is not cleared — it just stops counting as an edit.
+  const isEditing = editingRound === session?.activeRoundNumber && round?.state === "open";
+  const liveEditingRound = isEditing ? editingRound : null;
 
-  // Editing only survives while its round is open, so drop it when the round advances.
-  useEffect(() => {
-    setEditingRound(null);
-    setInputValue("");
-    setSelectedOption(null);
-  }, [session?.activeRoundNumber]);
+  const availableOptions = useAvailableOptions(options, mySelections, liveEditingRound);
 
   if (isLoading) return <Loading />;
   if (!session) return <DisplayError />;
@@ -99,14 +97,13 @@ export function Round({ sessionId, topic, year }: Props) {
     );
   }
 
-  const isEditing = editingRound !== null;
   const isDisabled = !selectedOption || (!isEditing && hasPickedThisRound);
 
   const onEnter = async () => {
     if (isDisabled || !selectedOption) return;
-    if (isEditing) {
+    if (liveEditingRound !== null) {
       const { error } = await tryCatch(
-        editSelection({ sessionId, roundNumber: editingRound, option: selectedOption }),
+        editSelection({ sessionId, roundNumber: liveEditingRound, option: selectedOption }),
       );
       if (error) {
         Sentry.captureException(error);

--- a/src/screens/settings.tsx
+++ b/src/screens/settings.tsx
@@ -1,9 +1,11 @@
+import * as Sentry from "@sentry/react";
 import { useNavigate } from "@tanstack/react-router";
 
 import { Button } from "components/button";
 import { Container } from "components/container";
 import { PlayerList } from "components/lists/players";
 import { Loading } from "components/states/loading";
+import { useToast } from "components/toast/use-toast";
 import { api } from "convex/_generated/api";
 import { useMutation } from "convex/react";
 import type { SessionID } from "db/types";
@@ -11,6 +13,8 @@ import { usePlayers } from "db/use-players";
 import { useSelections } from "db/use-selections";
 import { useSession } from "db/use-sessions";
 import { useGameOver } from "hooks/use-game-over";
+import { getApiError } from "utils/api-error";
+import { tryCatch } from "utils/try-catch";
 
 interface Props {
   sessionId: SessionID;
@@ -19,6 +23,7 @@ interface Props {
 
 export function Settings({ sessionId, round }: Props) {
   const navigate = useNavigate();
+  const toast = useToast();
   const { isLoading: isSessionLoading, session } = useSession(sessionId);
   const { isLoading: isPlayersLoading, players, isHost } = usePlayers(sessionId);
   const { isLoading: isSelectionsLoading, selections } = useSelections(sessionId, round);
@@ -35,10 +40,12 @@ export function Settings({ sessionId, round }: Props) {
   const completedUids = new Set(selections.map((s) => s.uid));
 
   const onNextRound = async () => {
-    await advanceRound({
-      sessionId,
-      currentRoundNumber: round,
-    });
+    const { error } = await tryCatch(advanceRound({ sessionId, currentRoundNumber: round }));
+    if (error) {
+      Sentry.captureException(error);
+      toast.show({ message: getApiError(error).message, variant: "error" });
+      return;
+    }
     window.history.back();
   };
 


### PR DESCRIPTION
## Summary

`advanceRound`, `saveSelection` and `editSelection` were auth-only: any authenticated user could force-advance another session's round, insert picks into a session they never joined, or rewrite a pick after its round closed. This adds membership, host, rate-limit and state guards per the ticket, with `convex-test` negative-authz coverage, and brings the UI in line with the new server contract.

Closes #77

## Changes

- `convex/utils/auth.ts`: `requireSessionMember` throws `NOT_MEMBER` instead of returning `null`, per the authz-throws contract.
- `convex/rounds.ts` `advanceRound`: member guard, host guard (`players.by_session_uid` + `isHost`), rate limit, and a state assert so only an `open`/`revealing` round advances.
- `convex/selections.ts`: `saveSelection` gets the member guard; `editSelection` gets member guard, rate limit, and a `round.state === "open"` assert.
- `convex/ratelimits.ts`: `editSelection` (20/min) and `advanceRound` (30/min) buckets.
- `convex/__tests__/rounds.test.ts`, `selections.test.ts`, `harness.setup.ts`: 19 new `convex-test` cases (non-member, non-host, wrong state, happy path).
- `src/components/lists/picks.tsx`, `src/screens/round/round.tsx`: Edit only on the open round; pending edit dropped when the round advances.
- `src/components/sidebar/sidebar-content.tsx`: Leave Game navigates home before awaiting the mutation so the leaver's subscriptions don't throw into the root ErrorBoundary.
- `src/screens/settings.tsx`: `onNextRound` wrapped in `tryCatch` + Sentry + toast.
- `playwright/game/single-player.e2e.ts`, `multiplayer.e2e.ts`: closed round asserts no Edit; positive edit coverage moved to multiplayer where the round stays open.

## Verification

Pipeline: implement (Opus) → adversarial review → one fix pass → review 2. Locally on the rebased branch: `check:format`, `check:lint`, `check:types`, `bun test` (67 pass, 19 new). E2E not run locally (needs the functions on a deployment); CI covers it.

Review 2 left three items open, none of them code fixes: the product decision below, the dep disclosure below, and a nit that a failed `leaveSession` now leaves the player on home still a member (toast only).

## Notes for reviewer

- **Product decision, yours:** edit-after-reveal is gone. The ticket's `round.state === "open"` assert makes editing a closed pick impossible, so the Edit button is gated rather than being a guaranteed error toast. A solo game therefore has no edit window at all (a solo round flips to `revealing` the instant you pick). If you want editing back, narrow the assert to "until the session is ENDED"; the member guard already closes the cross-session hole.
- **New devDependency: `convex-test`** (+ `bun.lock`). The repo had no Convex unit coverage; `.claude/rules/convex.md` and `testing.md` require it for every changed function. A prior run of this ticket blocked on the old forbidden-zones rule that #137 replaced with this disclosure.
- `harness.setup.ts` builds the module map by hand (Bun has no `import.meta.glob`) and registers the rate limiter from `@convex-dev/rate-limiter/src/component/` because the package's `/test` entrypoint also relies on `import.meta.glob`. Test-only; breaks loudly if the package stops shipping `src/`. `*.setup.ts`/`*.test.ts` have two dots so the Convex bundler skips them on deploy.
- Authz-throws is user-visible: `getRound`, `getSelections`, `getMySelections`, `getResults` now throw for a player whose row is gone, so a kicked player gets `DisplayError` with a home link instead of a silently empty list.
- Look first at `convex/selections.ts` and `convex/rounds.ts`, then `round.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
