### PR TITLE
chore(rules): commit scope is the area touched, not the author

### DIFF
--- a/.claude/skills/implement-ticket/SKILL.md
+++ b/.claude/skills/implement-ticket/SKILL.md
@@ -15,7 +15,7 @@ You are the pipeline's implement agent. The argument is a GitHub issue number in
 3. **Branch**: `git switch -c agent/<n>-<short-slug>` off `main`.
 4. **Implement** per the rules. Any new or changed Convex function ships `convex-test` coverage in this PR, including negative authz cases.
 5. **Verify**: `bun run check:format && bun run check:lint && bun run check:types && bun test`. Fix what fails. Never weaken a failing test to make it pass — if a test looks wrong, say so in the PR instead.
-6. **Commit**: `type(agent/<topic>): summary` (Conventional Commits; type ∈ feat|fix|chore|ci). The scope is a short descriptive TOPIC — e.g. `fix(agent/constants)`, `feat(agent/lobby)` — NEVER the issue number. Issue numbers belong only in the branch name and the `Closes #<n>` line. The PR title follows the same commit format.
+6. **Commit**: `type(scope): summary` (Conventional Commits; type ∈ feat|fix|chore|ci). The scope is the area touched — e.g. `fix(convex)`, `feat(lobby)` — NEVER the author and NEVER the issue number. Issue numbers belong only in the branch name and the `Closes #<n>` line. The PR title follows the same commit format.
 7. **Push and open the PR**: `gh pr create` filling every section of `.github/pull_request_template.md`: `## Summary` (MUST include `Closes #<n>` on its own line), `## Changes`, `## Verification` (say exactly what you ran and what you could not verify — no checkbox theatre), `## Notes for reviewer` (what to look at first, tradeoffs, anything you were unsure about).
 
 ## Blocked protocol

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,9 +23,8 @@ E2E: `bun run test:web` (Playwright, needs `.env.local`).
 
 ## Git
 
-- Conventional Commits: `type(scope): summary`, type ∈ `feat|fix|chore|ci`.
-- Human work: scope `seery/<topic>`, branches `seery/<topic>`.
-- Agent work: scope `agent/<topic>`, branches `agent/<issue#>-<slug>`.
+- Conventional Commits: `type(scope): summary`, type ∈ `feat|fix|chore|ci`. The scope is the area touched (`convex`, `lobby`, `round`, `ci`, `deps`, `rules`), never the author or the issue number. PR titles follow the same format.
+- Branches: human work `seery/<topic>`, agent work `agent/<issue#>-<slug>`. Provenance lives in the branch name and the `Co-Authored-By` trailer, not the commit scope.
 - Rebase onto the PR's base before pushing for review. `git log --oneline <base>..HEAD` shows only this PR's commits.
 - PRs fill every section of `.github/pull_request_template.md` (Summary / Changes / Verification / Notes for reviewer) and merge to `main` via squash or rebase only.
 - Never add a `Claude-Session` trailer to commits or a session link to PR bodies.


### PR DESCRIPTION
## Summary

Drops the `seery/` and `agent/` author prefixes from commit and PR-title scopes. Everything the pipeline does runs under the same GitHub account, so the prefix was the only at-a-glance provenance, but it squatted on the Conventional Commits scope. Provenance now lives in the branch name (`seery/<topic>`, `agent/<issue#>-<slug>`, unchanged) and the `Co-Authored-By` trailer; scope says where the change is (`convex`, `lobby`, `deps`, `rules`).

## Changes

- `CLAUDE.md` Git section: scope is the area touched, never author or issue number; branches carry provenance.
- `.claude/skills/implement-ticket/SKILL.md`: commit step updated to match.
- Pipeline prompts under `.pipeline/` (gitignored, on the mini): implement, fix, and PR-writer updated the same way.
- Issue #104 (PR-title lint) body updated so the eventual check validates `[a-z0-9-]+` rather than `(seery|agent)/…`.

## Verification

Docs only. Pre-commit hook ran (types clean). This PR's own title follows the new rule.

## Notes for reviewer

Touches `.claude/**`: the skill's commit-format line. Branch naming is intentionally unchanged; the runner creates and deletes `agent/<n>-…` branches by name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
