### PR TITLE
fix(lobby): redirect host to active round on lobby reload

### DIFF
--- a/playwright/pregame/lobby.e2e.ts
+++ b/playwright/pregame/lobby.e2e.ts
@@ -61,3 +61,23 @@ test("lobby: player leaves and host sees update", async ({ browser }) => {
   await hostContext.close();
   await guestContext.close();
 });
+
+test("lobby: host reopening the lobby URL mid-game lands on the active round", async ({ page }) => {
+  await page.goto("/");
+  await page.getByTestId("home-start").click();
+  await page.getByTestId("name-input").pressSequentially("Host");
+  await page.getByTestId("setup-submit").click();
+
+  await expect(page.getByTestId("lobby-start")).toBeVisible();
+  const sessionId = await page.getByTestId("session-id").getAttribute("data-value");
+
+  await page.getByTestId("lobby-start").click();
+  await expect(page.getByTestId("pick-input")).toBeVisible();
+
+  // Host reloads the lobby URL while the game is active
+  await page.goto(`/games/2026/${sessionId}`);
+
+  await expect(page).toHaveURL(`/games/2026/${sessionId}/10`);
+  await expect(page.getByTestId("pick-input")).toBeVisible();
+  await expect(page.getByTestId("lobby-start")).toHaveCount(0);
+});

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,22 +9,22 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as TopicRouteRouteImport } from './routes/$topic/route'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as TopicRouteRouteImport } from './routes/$topic/route'
 import { Route as TopicYearIndexRouteImport } from './routes/$topic/$year/index'
 import { Route as TopicYearSessionIdIndexRouteImport } from './routes/$topic/$year/$sessionId/index'
-import { Route as TopicYearSessionIdSettingsRouteImport } from './routes/$topic/$year/$sessionId/settings'
-import { Route as TopicYearSessionIdResultsRouteImport } from './routes/$topic/$year/$sessionId/results'
 import { Route as TopicYearSessionIdRoundRouteImport } from './routes/$topic/$year/$sessionId/$round'
+import { Route as TopicYearSessionIdResultsRouteImport } from './routes/$topic/$year/$sessionId/results'
+import { Route as TopicYearSessionIdSettingsRouteImport } from './routes/$topic/$year/$sessionId/settings'
 
-const TopicRouteRoute = TopicRouteRouteImport.update({
-  id: '/$topic',
-  path: '/$topic',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const TopicRouteRoute = TopicRouteRouteImport.update({
+  id: '/$topic',
+  path: '/$topic',
   getParentRoute: () => rootRouteImport,
 } as any)
 const TopicYearIndexRoute = TopicYearIndexRouteImport.update({
@@ -37,23 +37,23 @@ const TopicYearSessionIdIndexRoute = TopicYearSessionIdIndexRouteImport.update({
   path: '/$year/$sessionId/',
   getParentRoute: () => TopicRouteRoute,
 } as any)
-const TopicYearSessionIdSettingsRoute =
-  TopicYearSessionIdSettingsRouteImport.update({
-    id: '/$year/$sessionId/settings',
-    path: '/$year/$sessionId/settings',
-    getParentRoute: () => TopicRouteRoute,
-  } as any)
+const TopicYearSessionIdRoundRoute = TopicYearSessionIdRoundRouteImport.update({
+  id: '/$year/$sessionId/$round',
+  path: '/$year/$sessionId/$round',
+  getParentRoute: () => TopicRouteRoute,
+} as any)
 const TopicYearSessionIdResultsRoute =
   TopicYearSessionIdResultsRouteImport.update({
     id: '/$year/$sessionId/results',
     path: '/$year/$sessionId/results',
     getParentRoute: () => TopicRouteRoute,
   } as any)
-const TopicYearSessionIdRoundRoute = TopicYearSessionIdRoundRouteImport.update({
-  id: '/$year/$sessionId/$round',
-  path: '/$year/$sessionId/$round',
-  getParentRoute: () => TopicRouteRoute,
-} as any)
+const TopicYearSessionIdSettingsRoute =
+  TopicYearSessionIdSettingsRouteImport.update({
+    id: '/$year/$sessionId/settings',
+    path: '/$year/$sessionId/settings',
+    getParentRoute: () => TopicRouteRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -120,18 +120,18 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/$topic': {
-      id: '/$topic'
-      path: '/$topic'
-      fullPath: '/$topic'
-      preLoaderRoute: typeof TopicRouteRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/': {
       id: '/'
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/$topic': {
+      id: '/$topic'
+      path: '/$topic'
+      fullPath: '/$topic'
+      preLoaderRoute: typeof TopicRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/$topic/$year/': {
@@ -148,11 +148,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof TopicYearSessionIdIndexRouteImport
       parentRoute: typeof TopicRouteRoute
     }
-    '/$topic/$year/$sessionId/settings': {
-      id: '/$topic/$year/$sessionId/settings'
-      path: '/$year/$sessionId/settings'
-      fullPath: '/$topic/$year/$sessionId/settings'
-      preLoaderRoute: typeof TopicYearSessionIdSettingsRouteImport
+    '/$topic/$year/$sessionId/$round': {
+      id: '/$topic/$year/$sessionId/$round'
+      path: '/$year/$sessionId/$round'
+      fullPath: '/$topic/$year/$sessionId/$round'
+      preLoaderRoute: typeof TopicYearSessionIdRoundRouteImport
       parentRoute: typeof TopicRouteRoute
     }
     '/$topic/$year/$sessionId/results': {
@@ -162,11 +162,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof TopicYearSessionIdResultsRouteImport
       parentRoute: typeof TopicRouteRoute
     }
-    '/$topic/$year/$sessionId/$round': {
-      id: '/$topic/$year/$sessionId/$round'
-      path: '/$year/$sessionId/$round'
-      fullPath: '/$topic/$year/$sessionId/$round'
-      preLoaderRoute: typeof TopicYearSessionIdRoundRouteImport
+    '/$topic/$year/$sessionId/settings': {
+      id: '/$topic/$year/$sessionId/settings'
+      path: '/$year/$sessionId/settings'
+      fullPath: '/$topic/$year/$sessionId/settings'
+      preLoaderRoute: typeof TopicYearSessionIdSettingsRouteImport
       parentRoute: typeof TopicRouteRoute
     }
   }

--- a/src/screens/lobby/utils/use-lobby-state.ts
+++ b/src/screens/lobby/utils/use-lobby-state.ts
@@ -19,7 +19,7 @@ export function useLobbyState({ sessionId, topic, year }: LobbyProps) {
   useGameOver({ isHost, session });
 
   useEffect(() => {
-    if (!isLoading && session && session.status === SessionStatus.ACTIVE && !isHost) {
+    if (!isLoading && session && session.status === SessionStatus.ACTIVE) {
       navigate({
         to: "/$topic/$year/$sessionId/$round",
         params: {
@@ -31,7 +31,7 @@ export function useLobbyState({ sessionId, topic, year }: LobbyProps) {
         replace: true,
       });
     }
-  }, [isLoading, session?.status, isHost, topic.value, year, sessionId]);
+  }, [isLoading, session?.status, topic.value, year, sessionId]);
 
   return {
     isLoading,


### PR DESCRIPTION
## Summary

The lobby's active-round auto-redirect excluded the host (`&& !isHost`), so a host who reloaded or reopened the lobby URL mid-game stayed on the lobby with a live Start button — re-triggering the double-start race. The effect now redirects every member once `status === ACTIVE`; the host's own `onStart` navigation targets the same round, so the redundant `replace` navigation it triggers is a no-op.

Closes #89

## Changes

- `src/screens/lobby/utils/use-lobby-state.ts` — drop the `&& !isHost` guard on the active-round redirect effect, and drop `isHost` from its dependency array since it's no longer read.
- `playwright/pregame/lobby.e2e.ts` — add a spec: host reopens the lobby URL mid-game and lands on the active round instead of the lobby.

## Verification

- `check:format`, `check:lint`, `bunx tsc --noEmit`, and `bun test` (67 tests) all pass per gate.log.
- `bunx playwright test` (17 tests, including the new lobby spec) all pass per gate.log.
- Review (findings-1.json): verdict `approve`, zero findings. Reviewer independently confirmed the new test catches the regression by running it against the reverted hook, where it fails on the URL assertion. No fix pass ran since there was nothing to fix.

## Notes for reviewer

- Single-line behavior change plus its regression test — should be a quick read.
- The commit body notes the e2e suite couldn't run in the implementer's local sandbox (`EPERM listen 0.0.0.0:5173`); it did run here in the gate and passed, so that's resolved.
- No Convex functions changed, so no convex-test additions.
