### PR TITLE
ci(pr-title): lint PR titles for conventional commit format

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,20 @@
+name: PR title
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Conventional Commits format
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # type(scope): summary — type ∈ feat|fix|chore|ci; scope is the area touched
+          # ([a-z0-9-], e.g. convex, lobby, deps), never an issue number or seery/agent prefix.
+          if ! printf '%s\n' "$TITLE" | grep -Eq '^(feat|fix|chore|ci)\([a-z][a-z0-9-]*\): \S'; then
+            echo "::error::PR title must be 'type(scope): summary' (type feat|fix|chore|ci; scope = area touched, e.g. convex, lobby, deps — not an issue number or seery/agent prefix). Got: $TITLE"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

PR #103 landed with scope `agent/92`, an issue number plus author prefix, which CLAUDE.md forbids. This adds a CI check so the Conventional Commits title format is machine-checked. Squash merges land the PR title as the commit subject on `main`, so title-lint is commit-lint here.

Closes #104

## Changes

- `.github/workflows/pr-title.yml`: one job, one step. Greps the PR title against `^(feat|fix|chore|ci)\([a-z][a-z0-9-]*\): \S` and fails with an `::error::` annotation naming the expected shape. Runs on `opened`, `edited`, `reopened`, `synchronize`.

## Verification

Regex checked locally against sample titles: `ci(pr-title): …` passes; `fix(agent/89): …`, `chore(seery/drop): …`, `feat(92): …`, `feat(lobby):no space`, and `feat: no scope` are all rejected. The workflow itself cannot run until it is on `main`, since it triggers on PR events. No local gate checks apply to a YAML-only change.

## Notes for reviewer

- **`.github/**` change**: new workflow file, per the CLAUDE.md disclosure rule.
- Deliberately a single `run:` step rather than `amannn/action-semantic-pull-request` or a script with tests. The rule is one regex; the action's allowlist model cannot express "any area slug except issue numbers and author prefixes" without listing every scope.
- "Make it a required check via the ruleset" from the ticket is a repo-settings change, not a diff. Advisory until someone with ruleset access flips it.
- Rejects `type(scope)!:` breaking-change markers and scope-less titles, since CLAUDE.md's format has neither.
