### PR TITLE
fix(convex): assert session state on start, advance, end and reveal

### DIFF
--- a/convex/__tests__/harness.setup.ts
+++ b/convex/__tests__/harness.setup.ts
@@ -100,6 +100,24 @@ export async function seedActiveGame(t: TestConvex): Promise<SeededGame> {
   });
 }
 
+/**
+ * A LOBBY session with a host, one other member, and `MAX_ROUNDS` `pending`
+ * rounds (matching `createSession`).
+ */
+export async function seedLobbyGame(t: TestConvex): Promise<SeededGame> {
+  const game = await seedActiveGame(t);
+
+  await t.run(async (ctx) => {
+    await ctx.db.patch(game.sessionId, {
+      status: SessionStatus.LOBBY,
+      activeRoundNumber: 1,
+    });
+    await ctx.db.patch(game.roundIds[MAX_ROUNDS - 1], { state: "pending", startedAt: null });
+  });
+
+  return game;
+}
+
 export const OPTION = {
   id: 1234,
   name: "Blue Prince",
@@ -108,3 +126,18 @@ export const OPTION = {
   first_release_date: 1_744_000_000,
   summary: "A house of many doors.",
 };
+
+/** A saved `OPTION` pick by `uid` on the highest-numbered round. */
+export async function seedSelection(t: TestConvex, game: SeededGame, uid: string) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("selections", {
+      sessionId: game.sessionId,
+      roundId: game.roundIds[MAX_ROUNDS - 1],
+      uid,
+      pick: { id: String(OPTION.id), name: OPTION.name },
+      points: 1,
+      roundNumber: MAX_ROUNDS,
+      savedAt: Date.now(),
+    });
+  });
+}

--- a/convex/__tests__/rounds.test.ts
+++ b/convex/__tests__/rounds.test.ts
@@ -1,8 +1,15 @@
 import { describe, expect, it } from "bun:test";
 
-import { api } from "../_generated/api";
-import { MAX_ROUNDS } from "../constants";
-import { HOST_UID, MEMBER_UID, OUTSIDER_UID, seedActiveGame, setupTest } from "./harness.setup";
+import { api, internal } from "../_generated/api";
+import { MAX_ROUNDS, SessionStatus } from "../constants";
+import {
+  HOST_UID,
+  MEMBER_UID,
+  OUTSIDER_UID,
+  seedActiveGame,
+  seedSelection,
+  setupTest,
+} from "./harness.setup";
 
 describe("getRound", () => {
   it("throws for a non-member", async () => {
@@ -119,5 +126,74 @@ describe("advanceRound", () => {
         .withIdentity({ subject: HOST_UID })
         .mutation(api.rounds.advanceRound, { sessionId, currentRoundNumber: 1 }),
     ).rejects.toThrow(/WRONG_STATE/);
+  });
+
+  it("throws once the session has ended and leaves the rounds untouched", async () => {
+    const t = await setupTest();
+    const { sessionId, roundIds } = await seedActiveGame(t);
+    const host = t.withIdentity({ subject: HOST_UID });
+
+    await host.mutation(api.sessions.endSession, { sessionId });
+
+    await expect(
+      host.mutation(api.rounds.advanceRound, { sessionId, currentRoundNumber: MAX_ROUNDS }),
+    ).rejects.toThrow(/WRONG_STATE/);
+
+    const { current, next } = await t.run(async (ctx) => ({
+      current: await ctx.db.get(roundIds[MAX_ROUNDS - 1]),
+      next: await ctx.db.get(roundIds[MAX_ROUNDS - 2]),
+    }));
+
+    expect(current?.state).toBe("open");
+    expect(next?.state).toBe("pending");
+  });
+});
+
+describe("completeReveal", () => {
+  it("closes the revealing round and opens the next one", async () => {
+    const t = await setupTest();
+    const game = await seedActiveGame(t);
+    await seedSelection(t, game, MEMBER_UID);
+    const { sessionId, roundIds } = game;
+
+    await t
+      .withIdentity({ subject: HOST_UID })
+      .mutation(api.rounds.advanceRound, { sessionId, currentRoundNumber: MAX_ROUNDS });
+
+    await t.mutation(internal.rounds.completeReveal, { sessionId, roundNumber: MAX_ROUNDS });
+
+    const { session, current, next } = await t.run(async (ctx) => ({
+      session: await ctx.db.get(sessionId),
+      current: await ctx.db.get(roundIds[MAX_ROUNDS - 1]),
+      next: await ctx.db.get(roundIds[MAX_ROUNDS - 2]),
+    }));
+
+    expect(session?.activeRoundNumber).toBe(MAX_ROUNDS - 1);
+    expect(current?.state).toBe("closed");
+    expect(next?.state).toBe("open");
+  });
+
+  it("does nothing once the session has ended", async () => {
+    const t = await setupTest();
+    const game = await seedActiveGame(t);
+    await seedSelection(t, game, MEMBER_UID);
+    const host = t.withIdentity({ subject: HOST_UID });
+    const { sessionId, roundIds } = game;
+
+    await host.mutation(api.rounds.advanceRound, { sessionId, currentRoundNumber: MAX_ROUNDS });
+    await host.mutation(api.sessions.endSession, { sessionId });
+
+    await t.mutation(internal.rounds.completeReveal, { sessionId, roundNumber: MAX_ROUNDS });
+
+    const { session, current, next } = await t.run(async (ctx) => ({
+      session: await ctx.db.get(sessionId),
+      current: await ctx.db.get(roundIds[MAX_ROUNDS - 1]),
+      next: await ctx.db.get(roundIds[MAX_ROUNDS - 2]),
+    }));
+
+    expect(session?.status).toBe(SessionStatus.ENDED);
+    expect(session?.activeRoundNumber).toBe(MAX_ROUNDS);
+    expect(current?.state).toBe("revealing");
+    expect(next?.state).toBe("pending");
   });
 });

--- a/convex/__tests__/selections.test.ts
+++ b/convex/__tests__/selections.test.ts
@@ -9,25 +9,11 @@ import {
   OPTION,
   OUTSIDER_UID,
   seedActiveGame,
+  seedSelection,
   setupTest,
-  type SeededGame,
 } from "./harness.setup";
 
 type TestConvex = Awaited<ReturnType<typeof setupTest>>;
-
-async function seedSelection(t: TestConvex, game: SeededGame, uid: string) {
-  await t.run(async (ctx) => {
-    await ctx.db.insert("selections", {
-      sessionId: game.sessionId,
-      roundId: game.roundIds[MAX_ROUNDS - 1],
-      uid,
-      pick: { id: String(OPTION.id), name: OPTION.name },
-      points: 1,
-      roundNumber: MAX_ROUNDS,
-      savedAt: Date.now(),
-    });
-  });
-}
 
 async function setRoundState(
   t: TestConvex,

--- a/convex/__tests__/sessions.test.ts
+++ b/convex/__tests__/sessions.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "bun:test";
+
+import { api } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import { MAX_ROUNDS, SessionStatus } from "../constants";
+import {
+  HOST_UID,
+  MEMBER_UID,
+  OUTSIDER_UID,
+  seedActiveGame,
+  seedLobbyGame,
+  seedSelection,
+  setupTest,
+  type SeededGame,
+} from "./harness.setup";
+
+type TestConvex = Awaited<ReturnType<typeof setupTest>>;
+
+async function readGame(t: TestConvex, game: SeededGame) {
+  return await t.run(async (ctx) => ({
+    session: await ctx.db.get(game.sessionId),
+    current: await ctx.db.get(game.roundIds[MAX_ROUNDS - 1]),
+    next: await ctx.db.get(game.roundIds[MAX_ROUNDS - 2]),
+  }));
+}
+
+async function jobState(t: TestConvex, jobId: Id<"_scheduled_functions">) {
+  return await t.run(async (ctx) => (await ctx.db.system.get(jobId))?.state.kind);
+}
+
+describe("startSession", () => {
+  it("throws when unauthenticated", async () => {
+    const t = await setupTest();
+    const { sessionId } = await seedLobbyGame(t);
+
+    await expect(t.mutation(api.sessions.startSession, { sessionId })).rejects.toThrow(
+      /UNAUTHENTICATED/,
+    );
+  });
+
+  it("throws for a non-member and leaves the session in the lobby", async () => {
+    const t = await setupTest();
+    const game = await seedLobbyGame(t);
+
+    await expect(
+      t
+        .withIdentity({ subject: OUTSIDER_UID })
+        .mutation(api.sessions.startSession, { sessionId: game.sessionId }),
+    ).rejects.toThrow(/NOT_HOST/);
+
+    const { session } = await readGame(t, game);
+    expect(session?.status).toBe(SessionStatus.LOBBY);
+  });
+
+  it("throws for a member who is not the host and leaves the session in the lobby", async () => {
+    const t = await setupTest();
+    const game = await seedLobbyGame(t);
+
+    await expect(
+      t
+        .withIdentity({ subject: MEMBER_UID })
+        .mutation(api.sessions.startSession, { sessionId: game.sessionId }),
+    ).rejects.toThrow(/NOT_HOST/);
+
+    const { session, current } = await readGame(t, game);
+    expect(session?.status).toBe(SessionStatus.LOBBY);
+    expect(current?.state).toBe("pending");
+  });
+
+  it("opens the highest round for the host", async () => {
+    const t = await setupTest();
+    const game = await seedLobbyGame(t);
+
+    await t
+      .withIdentity({ subject: HOST_UID })
+      .mutation(api.sessions.startSession, { sessionId: game.sessionId });
+
+    const { session, current } = await readGame(t, game);
+    expect(session?.status).toBe(SessionStatus.ACTIVE);
+    expect(session?.activeRoundNumber).toBe(MAX_ROUNDS);
+    expect(current?.state).toBe("open");
+  });
+
+  it("throws on a second start and leaves the game where it was", async () => {
+    const t = await setupTest();
+    const game = await seedLobbyGame(t);
+    const host = t.withIdentity({ subject: HOST_UID });
+    const { sessionId } = game;
+
+    await host.mutation(api.sessions.startSession, { sessionId });
+    await host.mutation(api.rounds.advanceRound, { sessionId, currentRoundNumber: MAX_ROUNDS });
+
+    await expect(host.mutation(api.sessions.startSession, { sessionId })).rejects.toThrow(
+      /WRONG_STATE/,
+    );
+
+    const { session, current, next } = await readGame(t, game);
+    expect(session?.activeRoundNumber).toBe(MAX_ROUNDS - 1);
+    expect(current?.state).toBe("closed");
+    expect(next?.state).toBe("open");
+  });
+
+  it("throws once the session has ended", async () => {
+    const t = await setupTest();
+    const game = await seedActiveGame(t);
+    const host = t.withIdentity({ subject: HOST_UID });
+
+    await host.mutation(api.sessions.endSession, { sessionId: game.sessionId });
+
+    await expect(
+      host.mutation(api.sessions.startSession, { sessionId: game.sessionId }),
+    ).rejects.toThrow(/WRONG_STATE/);
+
+    const { session } = await readGame(t, game);
+    expect(session?.status).toBe(SessionStatus.ENDED);
+  });
+});
+
+describe("endSession", () => {
+  it("throws when unauthenticated", async () => {
+    const t = await setupTest();
+    const { sessionId } = await seedActiveGame(t);
+
+    await expect(t.mutation(api.sessions.endSession, { sessionId })).rejects.toThrow(
+      /UNAUTHENTICATED/,
+    );
+  });
+
+  it("throws for a non-member and leaves the session active", async () => {
+    const t = await setupTest();
+    const game = await seedActiveGame(t);
+
+    await expect(
+      t
+        .withIdentity({ subject: OUTSIDER_UID })
+        .mutation(api.sessions.endSession, { sessionId: game.sessionId }),
+    ).rejects.toThrow(/NOT_HOST/);
+
+    const { session } = await readGame(t, game);
+    expect(session?.status).toBe(SessionStatus.ACTIVE);
+  });
+
+  it("throws for a member who is not the host and leaves the session active", async () => {
+    const t = await setupTest();
+    const game = await seedActiveGame(t);
+
+    await expect(
+      t
+        .withIdentity({ subject: MEMBER_UID })
+        .mutation(api.sessions.endSession, { sessionId: game.sessionId }),
+    ).rejects.toThrow(/NOT_HOST/);
+
+    const { session } = await readGame(t, game);
+    expect(session?.status).toBe(SessionStatus.ACTIVE);
+  });
+
+  it("ends the session for the host", async () => {
+    const t = await setupTest();
+    const game = await seedActiveGame(t);
+
+    await t
+      .withIdentity({ subject: HOST_UID })
+      .mutation(api.sessions.endSession, { sessionId: game.sessionId });
+
+    const { session } = await readGame(t, game);
+    expect(session?.status).toBe(SessionStatus.ENDED);
+  });
+
+  it("throws when the session has already ended", async () => {
+    const t = await setupTest();
+    const game = await seedActiveGame(t);
+    const host = t.withIdentity({ subject: HOST_UID });
+
+    await host.mutation(api.sessions.endSession, { sessionId: game.sessionId });
+
+    await expect(
+      host.mutation(api.sessions.endSession, { sessionId: game.sessionId }),
+    ).rejects.toThrow(/SESSION_CLOSED/);
+  });
+
+  it("cancels the pending reveal job and clears the round's reveal fields", async () => {
+    const t = await setupTest();
+    const game = await seedActiveGame(t);
+    await seedSelection(t, game, MEMBER_UID);
+    const host = t.withIdentity({ subject: HOST_UID });
+    const { sessionId } = game;
+
+    await host.mutation(api.rounds.advanceRound, { sessionId, currentRoundNumber: MAX_ROUNDS });
+
+    const revealing = await t.run(async (ctx) => await ctx.db.get(game.roundIds[MAX_ROUNDS - 1]));
+    const jobId = revealing?.revealJobId;
+    if (!jobId) throw new Error("Expected advanceRound to schedule a reveal job");
+    expect(await jobState(t, jobId)).toBe("pending");
+
+    await host.mutation(api.sessions.endSession, { sessionId });
+
+    expect(await jobState(t, jobId)).toBe("canceled");
+
+    const { current } = await readGame(t, game);
+    expect(current?.revealJobId).toBeUndefined();
+    expect(current?.revealEndsAt).toBeUndefined();
+  });
+});

--- a/convex/rounds.ts
+++ b/convex/rounds.ts
@@ -4,6 +4,7 @@ import { internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import type { MutationCtx } from "./_generated/server";
 import { internalMutation, mutation, query } from "./_generated/server";
+import { SessionStatus } from "./constants";
 import { rateLimiter } from "./ratelimits";
 import { requireSessionMember } from "./utils/auth";
 import { apiError } from "./utils/errors";
@@ -42,6 +43,12 @@ export const advanceRound = mutation({
 
     await rateLimiter.limit(ctx, "advanceRound", { key: uid, throws: true });
 
+    const session = await ctx.db.get(sessionId);
+    if (!session) throw apiError("NOT_FOUND", "Session not found");
+    if (session.status !== SessionStatus.ACTIVE) {
+      throw apiError("WRONG_STATE", "Session is not in play");
+    }
+
     const currentRound = await ctx.db
       .query("rounds")
       .withIndex("by_session", (q) => q.eq("sessionId", sessionId))
@@ -71,9 +78,6 @@ export const advanceRound = mutation({
       return await completeRevealLogic(ctx, sessionId, currentRoundNumber, currentRound._id);
     }
 
-    const session = await ctx.db.get(sessionId);
-    if (!session) throw apiError("NOT_FOUND", "Session not found");
-
     const revealDurationMs = session.playerCount * 4_000 + 5_000;
     const revealEndsAt = Date.now() + revealDurationMs;
 
@@ -99,6 +103,12 @@ export const completeReveal = internalMutation({
     roundNumber: v.number(),
   },
   handler: async (ctx, { sessionId, roundNumber }) => {
+    // Internal: no auth or rate limit — only the scheduler reaches this, running
+    // jobs queued by `advanceRound` and `saveSelection`.
+    const session = await ctx.db.get(sessionId);
+    if (!session) throw apiError("NOT_FOUND", "Session not found");
+    if (session.status === SessionStatus.ENDED) return;
+
     const round = await getRoundByNumber(ctx.db, sessionId, roundNumber);
     if (!round) throw apiError("NOT_FOUND", "Round not found");
     if (round.state !== "revealing") return;

--- a/convex/sessions.ts
+++ b/convex/sessions.ts
@@ -88,8 +88,26 @@ export const endSession = mutation({
 
     if (!host?.isHost) throw apiError("NOT_HOST", "Only the host can end the session");
 
+    // No rate limit: a one-shot lifecycle transition — the ENDED assert below
+    // rejects every repeat, so there is nothing to throttle.
     const session = await ctx.db.get(sessionId);
     if (!session) throw apiError("NOT_FOUND", "Session not found");
+    if (session.status === SessionStatus.ENDED) {
+      throw apiError("SESSION_CLOSED", "Session has already ended");
+    }
+
+    // A reveal job scheduled by the round in play would fire after the session
+    // ends and re-open the next round — cancel it and clear its round fields.
+    const rounds = await ctx.db
+      .query("rounds")
+      .withIndex("by_session", (q) => q.eq("sessionId", sessionId))
+      .collect();
+
+    for (const round of rounds) {
+      if (!round.revealJobId) continue;
+      await ctx.scheduler.cancel(round.revealJobId);
+      await ctx.db.patch(round._id, { revealJobId: undefined, revealEndsAt: undefined });
+    }
 
     await ctx.db.patch(sessionId, { status: SessionStatus.ENDED });
   },
@@ -112,6 +130,12 @@ export const startSession = mutation({
       .unique();
 
     if (!host?.isHost) throw apiError("NOT_HOST", "Only the host can start the session");
+
+    // No rate limit: a one-shot lifecycle transition — the LOBBY assert below
+    // rejects every repeat, so there is nothing to throttle.
+    if (session.status !== SessionStatus.LOBBY) {
+      throw apiError("WRONG_STATE", "Session has already started");
+    }
 
     const round = await ctx.db
       .query("rounds")

--- a/src/screens/settings.tsx
+++ b/src/screens/settings.tsx
@@ -49,9 +49,14 @@ export function Settings({ sessionId, round }: Props) {
     window.history.back();
   };
 
-  const onLeaveGame = () => {
+  const onLeaveGame = async () => {
     if (isHost) {
-      endSession({ sessionId });
+      const { error } = await tryCatch(endSession({ sessionId }));
+      if (error) {
+        // Leave the room regardless — the host is done here either way.
+        Sentry.captureException(error);
+        toast.show({ message: getApiError(error).message, variant: "error" });
+      }
     }
     navigate({ to: "/", replace: true });
   };


### PR DESCRIPTION
## Summary

Three race windows let a host corrupt an in-flight or finished game: `startSession` had no `LOBBY` assert, so a second start reset `activeRoundNumber` and re-opened round 10 mid-game; `advanceRound` had no session-status assert, so the host could keep advancing rounds after the session ended; and `endSession` left the pending `completeReveal` scheduled job in place, so it fired later and re-opened the next round of an ended game. This PR adds state asserts to all three and makes `completeReveal` no-op on an `ENDED` session.

Closes #80

## Changes

- `convex/sessions.ts` — `startSession` throws `WRONG_STATE` unless the session is `LOBBY`; `endSession` throws `SESSION_CLOSED` on a repeat call and cancels any pending `revealJobId` per round (clearing `revealJobId`/`revealEndsAt`) before setting `ENDED`.
- `convex/rounds.ts` — `advanceRound` throws `WRONG_STATE` unless the session is `ACTIVE` (guard moved up the ladder, replacing a later duplicate session read); `completeReveal` no-ops when the session is already `ENDED`.
- `src/screens/settings.tsx` — host Leave button now awaits `endSession` through `tryCatch`, reporting to Sentry and toasting on error, matching the sidebar's Leave handler; still navigates home either way.
- `convex/__tests__/sessions.test.ts` (new) — covers both mutations: unauthenticated, non-member, non-host, wrong state, happy path, and reveal-job cancellation.
- `convex/__tests__/rounds.test.ts` — adds `completeReveal` cases (closes and opens next round; no-ops on `ENDED`) and an `advanceRound`-after-`endSession` case.
- `convex/__tests__/harness.setup.ts` — adds `seedLobbyGame`; `seedSelection` moved here from `selections.test.ts` so both suites share it.

## Verification

Per `gate.log`: `check:format`, `check:lint`, `bunx tsc --noEmit`, and `bun test` (82 pass / 0 fail) all clean; `bunx playwright test` (17 passed) also ran and passed.

Review flagged 4 findings, all resolved per `fix-report.md`:
- `should_fix` — `settings.tsx`'s Leave was fire-and-forget, so the new `SESSION_CLOSED` throw would become an unhandled rejection with no toast/Sentry — **fixed**, now wrapped in `tryCatch`.
- `nit` — stale comment on `completeReveal` said "the scheduler and `advanceRound`" reach it, but `advanceRound` calls `completeRevealLogic` directly — **fixed**, comment corrected to name `advanceRound` and `saveSelection` as the scheduling callers.
- `nit` — `startSession`/`endSession` skip the rate-limit rung with no comment — **fixed**, both now document why (one-shot lifecycle transitions; the state assert rejects every repeat, so nothing to throttle).
- `nit` — `endSession` is now non-idempotent, so a host double-tapping Leave sees a red toast for a harmless repeat — **skipped**, see Notes below.

## Notes for reviewer

Look at `convex/sessions.ts` (`startSession`, `endSession`) and `convex/rounds.ts` (`advanceRound`, `completeReveal`) first — that's the whole fix; the rest is tests and the one UI call site the new throw affects.

Tradeoff, from the fix-report (skipped, human call): kept `endSession` throwing `SESSION_CLOSED` on a repeat call rather than making it a silent no-op. `.claude/rules/convex.md` says state asserts throw and shouldn't be masked, and `sessions.test.ts` asserts that throw, so softening it would mean weakening that test. The cost is a benign but visible error toast if a host double-taps Leave (e.g. via the sidebar) on an already-ended session. Making `endSession` idempotent instead is a product call left to the reviewer.

From the implementer's commit message: the round-state guard the ticket also cites for `advanceRound` already landed in #139 separately; this PR's `advanceRound` change is the session-status assert, with the guard read moved up the ladder so the later duplicate `ctx.db.get(sessionId)` is gone.

No new dependencies, no CI or `.claude/` rules changes, no regenerated files.
