### PR TITLE
fix(convex): guard, rate limit and cache the option actions

### DIFF
--- a/convex/__tests__/options.test.ts
+++ b/convex/__tests__/options.test.ts
@@ -1,0 +1,187 @@
+import { afterAll, beforeEach, describe, expect, it } from "bun:test";
+
+import { api } from "../_generated/api";
+import { optionsKey } from "../utils/cache";
+import { MEMBER_UID, OUTSIDER_UID, setupTest } from "./harness.setup";
+
+// The actions must take the real third-party path, not the fixture shortcut.
+delete process.env.OPTIONS_FIXTURES;
+
+const mockMovie = {
+  id: 1,
+  title: "Sinners",
+  poster_path: "/sinners.jpg",
+  vote_average: 7.6,
+  release_date: "2025-03-07",
+  overview: "Twin brothers return home.",
+};
+
+const mockGame = {
+  id: 2,
+  name: "Blue Prince",
+  total_rating: 91,
+  first_release_date: 1_744_000_000,
+  summary: "A house of many doors.",
+};
+
+const mockBook = {
+  key: "/works/OL1W",
+  title: "The Emperor of Gladness",
+  first_publish_year: 2025,
+  cover_i: 42,
+  ratings_average: 4.5,
+  description: "A year in a dying town.",
+};
+
+const realFetch = globalThis.fetch;
+
+let requests: string[] = [];
+
+/** Set by the oversized-payload test; the IGDB mock serves this when present. */
+let oversizedGames: (typeof mockGame)[] | null = null;
+
+function json(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function mockFetch(input: string | URL | Request) {
+  const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+  requests.push(url);
+
+  if (url.includes("api.themoviedb.org"))
+    return Promise.resolve(json({ page: 1, total_pages: 1, results: [mockMovie] }));
+  if (url.includes("id.twitch.tv"))
+    return Promise.resolve(json({ access_token: "twitch-token", expires_in: 5_000_000 }));
+  if (url.includes("api.igdb.com")) return Promise.resolve(json(oversizedGames ?? [mockGame]));
+  if (url.includes("openlibrary.org"))
+    return Promise.resolve(json({ numFound: 1, docs: [mockBook] }));
+
+  throw new Error(`Unexpected fetch: ${url}`);
+}
+
+/** How many times the mock was asked for `host`. */
+function hits(host: string) {
+  return requests.filter((url) => url.includes(host)).length;
+}
+
+beforeEach(() => {
+  requests = [];
+  oversizedGames = null;
+  globalThis.fetch = mockFetch as unknown as typeof fetch;
+});
+
+afterAll(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe("option actions", () => {
+  it("throw when unauthenticated and call no third-party API", async () => {
+    const t = await setupTest();
+
+    await expect(t.action(api.tmdb.getMovies, { year: "2025" })).rejects.toThrow(/UNAUTHENTICATED/);
+    await expect(t.action(api.igdb.getGames, { year: "2025" })).rejects.toThrow(/UNAUTHENTICATED/);
+    await expect(t.action(api.openlibrary.getBooks, { year: "2025" })).rejects.toThrow(
+      /UNAUTHENTICATED/,
+    );
+
+    expect(requests).toEqual([]);
+  });
+
+  it("throw once the caller's rate-limit bucket is empty, per user", async () => {
+    const t = await setupTest();
+    const asMember = t.withIdentity({ subject: MEMBER_UID });
+
+    for (let i = 0; i < 10; i++) {
+      await asMember.action(api.openlibrary.getBooks, { year: "2025" });
+    }
+
+    await expect(asMember.action(api.openlibrary.getBooks, { year: "2025" })).rejects.toThrow(
+      /RateLimited/,
+    );
+
+    // A different user has their own bucket.
+    expect(
+      await t.withIdentity({ subject: OUTSIDER_UID }).action(api.openlibrary.getBooks, {
+        year: "2025",
+      }),
+    ).toEqual([mockBook]);
+  });
+});
+
+describe("option caching", () => {
+  it("fetches movies once per year and serves repeats from the cache", async () => {
+    const t = await setupTest();
+    const asMember = t.withIdentity({ subject: MEMBER_UID });
+
+    const first = await asMember.action(api.tmdb.getMovies, { year: "2025" });
+    const second = await asMember.action(api.tmdb.getMovies, { year: "2025" });
+
+    expect(first).toEqual([mockMovie]);
+    expect(second).toEqual([mockMovie]);
+    expect(hits("api.themoviedb.org")).toBe(1);
+
+    await asMember.action(api.tmdb.getMovies, { year: "2024" });
+
+    expect(hits("api.themoviedb.org")).toBe(2);
+  });
+
+  it("fetches books once per year and serves repeats from the cache", async () => {
+    const t = await setupTest();
+    const asMember = t.withIdentity({ subject: MEMBER_UID });
+
+    expect(await asMember.action(api.openlibrary.getBooks, { year: "2025" })).toEqual([mockBook]);
+    expect(await asMember.action(api.openlibrary.getBooks, { year: "2025" })).toEqual([mockBook]);
+
+    expect(hits("openlibrary.org")).toBe(1);
+  });
+
+  it("reuses the Twitch token across IGDB fetches for different years", async () => {
+    const t = await setupTest();
+    const asMember = t.withIdentity({ subject: MEMBER_UID });
+
+    expect(await asMember.action(api.igdb.getGames, { year: "2025" })).toEqual([mockGame]);
+    await asMember.action(api.igdb.getGames, { year: "2024" });
+    await asMember.action(api.igdb.getGames, { year: "2025" });
+
+    expect(hits("api.igdb.com")).toBe(2);
+    expect(hits("id.twitch.tv")).toBe(1);
+  });
+
+  it("serves but does not cache a payload too large for a Convex document", async () => {
+    const t = await setupTest();
+    const asMember = t.withIdentity({ subject: MEMBER_UID });
+    // Bigger than the 900KB write ceiling in `utils/cache`.
+    oversizedGames = Array.from({ length: 20 }, (_, i) => ({
+      ...mockGame,
+      id: i,
+      summary: "x".repeat(50_000),
+    }));
+
+    await asMember.action(api.igdb.getGames, { year: "2025" });
+    await asMember.action(api.igdb.getGames, { year: "2025" });
+
+    expect(hits("api.igdb.com")).toBe(2);
+    expect(await t.run(async (ctx) => await ctx.db.query("apiCache").collect())).toHaveLength(1);
+  });
+
+  it("refetches once the cached entry has expired", async () => {
+    const t = await setupTest();
+    const asMember = t.withIdentity({ subject: MEMBER_UID });
+
+    await asMember.action(api.tmdb.getMovies, { year: "2025" });
+
+    await t.run(async (ctx) => {
+      const entry = await ctx.db
+        .query("apiCache")
+        .withIndex("by_key", (q) => q.eq("key", optionsKey("movies", "2025")))
+        .unique();
+      await ctx.db.patch(entry!._id, { expiresAt: Date.now() - 1 });
+    });
+
+    expect(await asMember.action(api.tmdb.getMovies, { year: "2025" })).toEqual([mockMovie]);
+    expect(hits("api.themoviedb.org")).toBe(2);
+  });
+});

--- a/convex/__tests__/options.test.ts
+++ b/convex/__tests__/options.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeEach, describe, expect, it } from "bun:test";
 
 import { api } from "../_generated/api";
-import { optionsKey } from "../utils/cache";
+import { IGDB_TOKEN_KEY, optionsKey } from "../utils/cache";
 import { MEMBER_UID, OUTSIDER_UID, setupTest } from "./harness.setup";
 
 // The actions must take the real third-party path, not the fixture shortcut.
@@ -33,12 +33,18 @@ const mockBook = {
   description: "A year in a dying town.",
 };
 
+/** A cached token IGDB no longer honours. */
+const STALE_TOKEN = "stale-token";
+
 const realFetch = globalThis.fetch;
 
 let requests: string[] = [];
 
 /** Set by the oversized-payload test; the IGDB mock serves this when present. */
 let oversizedGames: (typeof mockGame)[] | null = null;
+
+/** Cleared by the malformed-token test, so the Twitch mock omits its expiry. */
+let tokenExpiresIn: number | null = 5_000_000;
 
 function json(body: unknown) {
   return new Response(JSON.stringify(body), {
@@ -47,15 +53,26 @@ function json(body: unknown) {
   });
 }
 
-function mockFetch(input: string | URL | Request) {
+function mockFetch(input: string | URL | Request, init?: RequestInit) {
   const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
   requests.push(url);
 
   if (url.includes("api.themoviedb.org"))
     return Promise.resolve(json({ page: 1, total_pages: 1, results: [mockMovie] }));
   if (url.includes("id.twitch.tv"))
-    return Promise.resolve(json({ access_token: "twitch-token", expires_in: 5_000_000 }));
-  if (url.includes("api.igdb.com")) return Promise.resolve(json(oversizedGames ?? [mockGame]));
+    return Promise.resolve(
+      json({
+        access_token: "twitch-token",
+        ...(tokenExpiresIn === null ? {} : { expires_in: tokenExpiresIn }),
+      }),
+    );
+  if (url.includes("api.igdb.com")) {
+    // IGDB rejects a revoked token, as it would after the secret was rotated.
+    const auth = (init?.headers as Record<string, string> | undefined)?.Authorization;
+    if (auth === `Bearer ${STALE_TOKEN}`) return Promise.resolve(new Response("", { status: 401 }));
+
+    return Promise.resolve(json(oversizedGames ?? [mockGame]));
+  }
   if (url.includes("openlibrary.org"))
     return Promise.resolve(json({ numFound: 1, docs: [mockBook] }));
 
@@ -70,6 +87,7 @@ function hits(host: string) {
 beforeEach(() => {
   requests = [];
   oversizedGames = null;
+  tokenExpiresIn = 5_000_000;
   globalThis.fetch = mockFetch as unknown as typeof fetch;
 });
 
@@ -109,6 +127,22 @@ describe("option actions", () => {
       }),
     ).toEqual([mockBook]);
   });
+
+  it("reject a year outside the picker's range and call no third-party API", async () => {
+    const t = await setupTest();
+    const asMember = t.withIdentity({ subject: MEMBER_UID });
+
+    for (const year of ["1900", "9999", "not-a-year"]) {
+      await expect(asMember.action(api.tmdb.getMovies, { year })).rejects.toThrow(/Invalid year/);
+      await expect(asMember.action(api.igdb.getGames, { year })).rejects.toThrow(/Invalid year/);
+      await expect(asMember.action(api.openlibrary.getBooks, { year })).rejects.toThrow(
+        /Invalid year/,
+      );
+    }
+
+    expect(requests).toEqual([]);
+    expect(await t.run(async (ctx) => await ctx.db.query("apiCache").collect())).toEqual([]);
+  });
 });
 
 describe("option caching", () => {
@@ -138,6 +172,17 @@ describe("option caching", () => {
     expect(hits("openlibrary.org")).toBe(1);
   });
 
+  it("shares one cache row across spellings of the same year", async () => {
+    const t = await setupTest();
+    const asMember = t.withIdentity({ subject: MEMBER_UID });
+
+    await asMember.action(api.tmdb.getMovies, { year: "2025" });
+    expect(await asMember.action(api.tmdb.getMovies, { year: "02025" })).toEqual([mockMovie]);
+
+    expect(hits("api.themoviedb.org")).toBe(1);
+    expect(await t.run(async (ctx) => await ctx.db.query("apiCache").collect())).toHaveLength(1);
+  });
+
   it("reuses the Twitch token across IGDB fetches for different years", async () => {
     const t = await setupTest();
     const asMember = t.withIdentity({ subject: MEMBER_UID });
@@ -148,6 +193,55 @@ describe("option caching", () => {
 
     expect(hits("api.igdb.com")).toBe(2);
     expect(hits("id.twitch.tv")).toBe(1);
+  });
+
+  it("mints a fresh Twitch token and retries when IGDB rejects the cached one", async () => {
+    const t = await setupTest();
+    const asMember = t.withIdentity({ subject: MEMBER_UID });
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("apiCache", {
+        key: IGDB_TOKEN_KEY,
+        value: STALE_TOKEN,
+        expiresAt: Date.now() + 60_000,
+      });
+    });
+
+    expect(await asMember.action(api.igdb.getGames, { year: "2025" })).toEqual([mockGame]);
+
+    // The 401 with the stale token, then the retry with the freshly minted one.
+    expect(hits("api.igdb.com")).toBe(2);
+    expect(hits("id.twitch.tv")).toBe(1);
+
+    // The stale token is gone, so the next call starts from the working one.
+    expect(
+      await t.run(async (ctx) =>
+        ctx.db
+          .query("apiCache")
+          .withIndex("by_key", (q) => q.eq("key", IGDB_TOKEN_KEY))
+          .unique(),
+      ),
+    ).toMatchObject({ value: "twitch-token" });
+  });
+
+  it("does not cache a Twitch token whose response carries no expiry", async () => {
+    const t = await setupTest();
+    const asMember = t.withIdentity({ subject: MEMBER_UID });
+    tokenExpiresIn = null;
+
+    await asMember.action(api.igdb.getGames, { year: "2025" });
+    await asMember.action(api.igdb.getGames, { year: "2024" });
+
+    // A NaN TTL must be skipped, not stored as an expiry that never lapses.
+    expect(hits("id.twitch.tv")).toBe(2);
+    expect(
+      await t.run(async (ctx) =>
+        ctx.db
+          .query("apiCache")
+          .withIndex("by_key", (q) => q.eq("key", IGDB_TOKEN_KEY))
+          .unique(),
+      ),
+    ).toBeNull();
   });
 
   it("serves but does not cache a payload too large for a Convex document", async () => {
@@ -176,7 +270,7 @@ describe("option caching", () => {
     await t.run(async (ctx) => {
       const entry = await ctx.db
         .query("apiCache")
-        .withIndex("by_key", (q) => q.eq("key", optionsKey("movies", "2025")))
+        .withIndex("by_key", (q) => q.eq("key", optionsKey("movies", 2025)))
         .unique();
       await ctx.db.patch(entry!._id, { expiresAt: Date.now() - 1 });
     });

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -9,6 +9,7 @@
  */
 
 import type * as auth from "../auth.js";
+import type * as cache from "../cache.js";
 import type * as constants from "../constants.js";
 import type * as crons from "../crons.js";
 import type * as http from "../http.js";
@@ -24,6 +25,7 @@ import type * as test_http from "../test/http.js";
 import type * as test_seed from "../test/seed.js";
 import type * as tmdb from "../tmdb.js";
 import type * as utils_auth from "../utils/auth.js";
+import type * as utils_cache from "../utils/cache.js";
 import type * as utils_dates from "../utils/dates.js";
 import type * as utils_pick from "../utils/pick.js";
 import type * as utils_rounds from "../utils/rounds.js";
@@ -37,6 +39,7 @@ import type {
 
 declare const fullApi: ApiFromModules<{
   auth: typeof auth;
+  cache: typeof cache;
   constants: typeof constants;
   crons: typeof crons;
   http: typeof http;
@@ -52,6 +55,7 @@ declare const fullApi: ApiFromModules<{
   "test/seed": typeof test_seed;
   tmdb: typeof tmdb;
   "utils/auth": typeof utils_auth;
+  "utils/cache": typeof utils_cache;
   "utils/dates": typeof utils_dates;
   "utils/pick": typeof utils_pick;
   "utils/rounds": typeof utils_rounds;

--- a/convex/cache.ts
+++ b/convex/cache.ts
@@ -1,0 +1,39 @@
+import { v } from "convex/values";
+
+import { internalMutation, internalQuery } from "./_generated/server";
+
+/**
+ * Read/write halves of the `apiCache` table. Actions have no `ctx.db`, so the
+ * option actions reach these through the `utils/cache` helpers.
+ */
+
+export const read = internalQuery({
+  args: { key: v.string() },
+  handler: async (ctx, { key }) => {
+    const entry = await ctx.db
+      .query("apiCache")
+      .withIndex("by_key", (q) => q.eq("key", key))
+      .unique();
+
+    if (!entry || entry.expiresAt <= Date.now()) return null;
+
+    return entry.value;
+  },
+});
+
+export const write = internalMutation({
+  args: { key: v.string(), value: v.any(), expiresAt: v.number() },
+  handler: async (ctx, { key, value, expiresAt }) => {
+    const entry = await ctx.db
+      .query("apiCache")
+      .withIndex("by_key", (q) => q.eq("key", key))
+      .unique();
+
+    if (entry) {
+      await ctx.db.patch(entry._id, { value, expiresAt });
+      return;
+    }
+
+    await ctx.db.insert("apiCache", { key, value, expiresAt });
+  },
+});

--- a/convex/constants.ts
+++ b/convex/constants.ts
@@ -1,6 +1,15 @@
 export const MAX_ROUNDS = 10;
 export const MAX_PLAYERS = 10;
 
+/** Option topics. Mirrors `TOPIC_KEY` in `src/constants/topics.ts`. */
+export const Topic = {
+  GAMES: "games",
+  MOVIES: "movies",
+  BOOKS: "books",
+} as const;
+
+export type TopicKey = (typeof Topic)[keyof typeof Topic];
+
 export const SessionStatus = {
   LOBBY: "lobby",
   ACTIVE: "active",

--- a/convex/igdb.ts
+++ b/convex/igdb.ts
@@ -1,11 +1,38 @@
 import { v } from "convex/values";
 
 import { action } from "./_generated/server";
+import type { ActionCtx } from "./_generated/server";
+import { Topic } from "./constants";
 import { fixtureGames } from "./test/fixtures";
+import { requireOptionsAccess } from "./utils/auth";
+import {
+  IGDB_TOKEN_KEY,
+  OPTIONS_TTL_MS,
+  optionsKey,
+  readCache,
+  TOKEN_TTL_SKEW_MS,
+  writeCache,
+} from "./utils/cache";
 import { currentYear } from "./utils/dates";
 import { useFixtures } from "./utils/env";
 
-async function getAccessToken(): Promise<string> {
+interface Game {
+  id: number;
+  name: string;
+  cover?: { id: number; url: string };
+  rating?: number;
+  aggregated_rating?: number;
+  total_rating?: number;
+  total_rating_count?: number;
+  first_release_date: number;
+  summary?: string;
+}
+
+/** Twitch client-credentials tokens live ~60 days; mint one and reuse it. */
+async function getAccessToken(ctx: ActionCtx): Promise<string> {
+  const cached = await readCache<string>(ctx, IGDB_TOKEN_KEY);
+  if (cached) return cached;
+
   const response = await fetch("https://id.twitch.tv/oauth2/token", {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -18,17 +45,31 @@ async function getAccessToken(): Promise<string> {
 
   // internal: plain Error — nothing user-actionable; UI shows its generic load failure
   if (!response.ok) throw new Error(`Twitch OAuth error: ${response.status}`);
-  const data = (await response.json()) as { access_token: string };
+  const data = (await response.json()) as { access_token: string; expires_in: number };
+
+  await writeCache(
+    ctx,
+    IGDB_TOKEN_KEY,
+    data.access_token,
+    data.expires_in * 1000 - TOKEN_TTL_SKEW_MS,
+  );
+
   return data.access_token;
 }
 
 export const getGames = action({
   args: { year: v.string() },
-  handler: async (_, { year }) => {
+  handler: async (ctx, { year }) => {
+    await requireOptionsAccess(ctx, "getGames");
+
     if (useFixtures()) return fixtureGames(year);
 
+    const key = optionsKey(Topic.GAMES, year);
+    const cached = await readCache<Game[]>(ctx, key);
+    if (cached) return cached;
+
     const { startDate, endDate } = currentYear(year);
-    const accessToken = await getAccessToken();
+    const accessToken = await getAccessToken(ctx);
 
     const response = await fetch("https://api.igdb.com/v4/games", {
       method: "POST",
@@ -48,6 +89,11 @@ export const getGames = action({
 
     // internal: plain Error — nothing user-actionable; UI shows its generic load failure
     if (!response.ok) throw new Error(`IGDB error: ${response.status}`);
-    return response.json();
+
+    const games: Game[] = await response.json();
+
+    await writeCache(ctx, key, games, OPTIONS_TTL_MS);
+
+    return games;
   },
 });

--- a/convex/igdb.ts
+++ b/convex/igdb.ts
@@ -28,10 +28,17 @@ interface Game {
   summary?: string;
 }
 
-/** Twitch client-credentials tokens live ~60 days; mint one and reuse it. */
-async function getAccessToken(ctx: ActionCtx): Promise<string> {
-  const cached = await readCache<string>(ctx, IGDB_TOKEN_KEY);
-  if (cached) return cached;
+/**
+ * Twitch client-credentials tokens live ~60 days; mint one and reuse it.
+ * `refresh` skips the cached token and overwrites it — the way out when IGDB
+ * rejects the cached one (a rotated `IGDB_CLIENT_SECRET` revokes it long before
+ * its TTL lapses, and there is no way to clear the cache on prod).
+ */
+async function getAccessToken(ctx: ActionCtx, refresh = false): Promise<string> {
+  if (!refresh) {
+    const cached = await readCache<string>(ctx, IGDB_TOKEN_KEY);
+    if (cached) return cached;
+  }
 
   const response = await fetch("https://id.twitch.tv/oauth2/token", {
     method: "POST",
@@ -61,31 +68,36 @@ export const getGames = action({
   args: { year: v.string() },
   handler: async (ctx, { year }) => {
     await requireOptionsAccess(ctx, "getGames");
+    const { year: releaseYear, startDate, endDate } = currentYear(year);
 
     if (useFixtures()) return fixtureGames(year);
 
-    const key = optionsKey(Topic.GAMES, year);
+    const key = optionsKey(Topic.GAMES, releaseYear);
     const cached = await readCache<Game[]>(ctx, key);
     if (cached) return cached;
 
-    const { startDate, endDate } = currentYear(year);
-    const accessToken = await getAccessToken(ctx);
+    const fetchGames = (accessToken: string) =>
+      fetch("https://api.igdb.com/v4/games", {
+        method: "POST",
+        headers: {
+          "Client-ID": process.env.IGDB_CLIENT_ID!,
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "text/plain",
+        },
+        body: `
+          fields name, cover.url, rating, aggregated_rating, total_rating, total_rating_count, first_release_date, summary;
+          where first_release_date >= ${startDate} & first_release_date < ${endDate}
+            & total_rating != null;
+          sort total_rating desc;
+          limit 500;
+        `,
+      });
 
-    const response = await fetch("https://api.igdb.com/v4/games", {
-      method: "POST",
-      headers: {
-        "Client-ID": process.env.IGDB_CLIENT_ID!,
-        Authorization: `Bearer ${accessToken}`,
-        "Content-Type": "text/plain",
-      },
-      body: `
-        fields name, cover.url, rating, aggregated_rating, total_rating, total_rating_count, first_release_date, summary;
-        where first_release_date >= ${startDate} & first_release_date < ${endDate}
-          & total_rating != null;
-        sort total_rating desc;
-        limit 500;
-      `,
-    });
+    let response = await fetchGames(await getAccessToken(ctx));
+
+    // A 401 means the cached token is dead (secret rotated, token revoked) well
+    // before its TTL — mint a fresh one and retry once rather than stay wedged.
+    if (response.status === 401) response = await fetchGames(await getAccessToken(ctx, true));
 
     // internal: plain Error — nothing user-actionable; UI shows its generic load failure
     if (!response.ok) throw new Error(`IGDB error: ${response.status}`);

--- a/convex/openlibrary.ts
+++ b/convex/openlibrary.ts
@@ -5,6 +5,7 @@ import { Topic } from "./constants";
 import { fixtureBooks } from "./test/fixtures";
 import { requireOptionsAccess } from "./utils/auth";
 import { OPTIONS_TTL_MS, optionsKey, readCache, writeCache } from "./utils/cache";
+import { parseYear } from "./utils/dates";
 import { useFixtures } from "./utils/env";
 
 interface OpenLibraryBook {
@@ -25,15 +26,16 @@ export const getBooks = action({
   args: { year: v.string() },
   handler: async (ctx, { year }) => {
     await requireOptionsAccess(ctx, "getBooks");
+    const publishYear = parseYear(year);
 
     if (useFixtures()) return fixtureBooks(year);
 
-    const key = optionsKey(Topic.BOOKS, year);
+    const key = optionsKey(Topic.BOOKS, publishYear);
     const cached = await readCache<OpenLibraryBook[]>(ctx, key);
     if (cached) return cached;
 
     const response = await fetch(
-      `https://openlibrary.org/search.json?q=first_publish_year:${year}&sort=rating&limit=40&fields=key,title,first_publish_year,cover_i,ratings_average,description`,
+      `https://openlibrary.org/search.json?q=first_publish_year:${publishYear}&sort=rating&limit=40&fields=key,title,first_publish_year,cover_i,ratings_average,description`,
       { headers: { "User-Agent": "WhatOfTheYear/1.0" } },
     );
 

--- a/convex/openlibrary.ts
+++ b/convex/openlibrary.ts
@@ -1,7 +1,10 @@
 import { v } from "convex/values";
 
 import { action } from "./_generated/server";
+import { Topic } from "./constants";
 import { fixtureBooks } from "./test/fixtures";
+import { requireOptionsAccess } from "./utils/auth";
+import { OPTIONS_TTL_MS, optionsKey, readCache, writeCache } from "./utils/cache";
 import { useFixtures } from "./utils/env";
 
 interface OpenLibraryBook {
@@ -20,8 +23,14 @@ interface OpenLibraryResponse {
 
 export const getBooks = action({
   args: { year: v.string() },
-  handler: async (_, { year }) => {
+  handler: async (ctx, { year }) => {
+    await requireOptionsAccess(ctx, "getBooks");
+
     if (useFixtures()) return fixtureBooks(year);
+
+    const key = optionsKey(Topic.BOOKS, year);
+    const cached = await readCache<OpenLibraryBook[]>(ctx, key);
+    if (cached) return cached;
 
     const response = await fetch(
       `https://openlibrary.org/search.json?q=first_publish_year:${year}&sort=rating&limit=40&fields=key,title,first_publish_year,cover_i,ratings_average,description`,
@@ -32,6 +41,8 @@ export const getBooks = action({
     if (!response.ok) throw new Error(`Open Library error: ${response.status}`);
 
     const data: OpenLibraryResponse = await response.json();
+
+    await writeCache(ctx, key, data.docs, OPTIONS_TTL_MS);
 
     return data.docs;
   },

--- a/convex/ratelimits.ts
+++ b/convex/ratelimits.ts
@@ -8,4 +8,8 @@ export const rateLimiter = new RateLimiter(components.rateLimiter, {
   saveSelection: { kind: "token bucket", rate: 20, period: MINUTE },
   editSelection: { kind: "token bucket", rate: 20, period: MINUTE },
   advanceRound: { kind: "token bucket", rate: 30, period: MINUTE },
+  // Option actions: one fetch per topic/year, cached server-side afterwards.
+  getMovies: { kind: "token bucket", rate: 10, period: MINUTE },
+  getGames: { kind: "token bucket", rate: 10, period: MINUTE },
+  getBooks: { kind: "token bucket", rate: 10, period: MINUTE },
 });

--- a/convex/reset.ts
+++ b/convex/reset.ts
@@ -12,6 +12,7 @@ export const clearAll = internalMutation({
       "players",
       "rounds",
       "selections",
+      "apiCache",
       "authAccounts",
       "authSessions",
       "authVerificationCodes",

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -64,4 +64,13 @@ export default defineSchema({
   })
     .index("by_round_uid", ["roundId", "uid"])
     .index("by_session", ["sessionId"]),
+
+  // Third-party responses (option lists per topic/year, the IGDB access token),
+  // keyed by `utils/cache` key builders. One row per key — writes overwrite,
+  // so the table stays bounded and needs no sweeper.
+  apiCache: defineTable({
+    key: v.string(),
+    value: v.any(),
+    expiresAt: v.number(),
+  }).index("by_key", ["key"]),
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -66,8 +66,9 @@ export default defineSchema({
     .index("by_session", ["sessionId"]),
 
   // Third-party responses (option lists per topic/year, the IGDB access token),
-  // keyed by `utils/cache` key builders. One row per key — writes overwrite,
-  // so the table stays bounded and needs no sweeper.
+  // keyed by `utils/cache` key builders. One row per key — writes overwrite, and
+  // the year in a key is parsed and range-checked first, so the table stays
+  // bounded (topics x offered years, plus the token) and needs no sweeper.
   apiCache: defineTable({
     key: v.string(),
     value: v.any(),

--- a/convex/tmdb.ts
+++ b/convex/tmdb.ts
@@ -1,7 +1,10 @@
 import { v } from "convex/values";
 
 import { action } from "./_generated/server";
+import { Topic } from "./constants";
 import { fixtureMovies } from "./test/fixtures";
+import { requireOptionsAccess } from "./utils/auth";
+import { OPTIONS_TTL_MS, optionsKey, readCache, writeCache } from "./utils/cache";
 import { useFixtures } from "./utils/env";
 
 interface Movie {
@@ -21,8 +24,14 @@ interface TMDBResponse {
 
 export const getMovies = action({
   args: { year: v.string() },
-  handler: async (_, { year }) => {
+  handler: async (ctx, { year }) => {
+    await requireOptionsAccess(ctx, "getMovies");
+
     if (useFixtures()) return fixtureMovies(year);
+
+    const key = optionsKey(Topic.MOVIES, year);
+    const cached = await readCache<Movie[]>(ctx, key);
+    if (cached) return cached;
 
     const startDate = `${year}-01-01`;
     const endDate = `${year}-12-31`;
@@ -44,6 +53,8 @@ export const getMovies = action({
       totalPages = data.total_pages;
       page++;
     }
+
+    await writeCache(ctx, key, allMovies, OPTIONS_TTL_MS);
 
     return allMovies;
   },

--- a/convex/tmdb.ts
+++ b/convex/tmdb.ts
@@ -5,6 +5,7 @@ import { Topic } from "./constants";
 import { fixtureMovies } from "./test/fixtures";
 import { requireOptionsAccess } from "./utils/auth";
 import { OPTIONS_TTL_MS, optionsKey, readCache, writeCache } from "./utils/cache";
+import { parseYear } from "./utils/dates";
 import { useFixtures } from "./utils/env";
 
 interface Movie {
@@ -26,15 +27,16 @@ export const getMovies = action({
   args: { year: v.string() },
   handler: async (ctx, { year }) => {
     await requireOptionsAccess(ctx, "getMovies");
+    const releaseYear = parseYear(year);
 
     if (useFixtures()) return fixtureMovies(year);
 
-    const key = optionsKey(Topic.MOVIES, year);
+    const key = optionsKey(Topic.MOVIES, releaseYear);
     const cached = await readCache<Movie[]>(ctx, key);
     if (cached) return cached;
 
-    const startDate = `${year}-01-01`;
-    const endDate = `${year}-12-31`;
+    const startDate = `${releaseYear}-01-01`;
+    const endDate = `${releaseYear}-12-31`;
     const allMovies: Movie[] = [];
     let page = 1;
     let totalPages = 1;

--- a/convex/utils/auth.ts
+++ b/convex/utils/auth.ts
@@ -1,5 +1,6 @@
 import type { Id } from "../_generated/dataModel";
-import type { QueryCtx } from "../_generated/server";
+import type { ActionCtx, QueryCtx } from "../_generated/server";
+import { rateLimiter } from "../ratelimits";
 import { apiError } from "./errors";
 
 export async function requireSessionMember(ctx: QueryCtx, sessionId: Id<"sessions">) {
@@ -14,4 +15,22 @@ export async function requireSessionMember(ctx: QueryCtx, sessionId: Id<"session
   if (!player) throw apiError("NOT_MEMBER", "Player not in session");
 
   return identity;
+}
+
+/**
+ * Guard for the option actions (`getMovies`/`getGames`/`getBooks`): auth, then a
+ * per-user rate limit so a signed-in caller can't burn third-party quota or
+ * action minutes in a loop.
+ *
+ * No membership step — options are picked on the topic/year screen before a
+ * session exists, so there is no session to be a member of.
+ */
+export async function requireOptionsAccess(
+  ctx: ActionCtx,
+  name: "getMovies" | "getGames" | "getBooks",
+) {
+  const identity = await ctx.auth.getUserIdentity();
+  if (!identity) throw apiError("UNAUTHENTICATED", "Unauthenticated");
+
+  await rateLimiter.limit(ctx, name, { key: identity.subject, throws: true });
 }

--- a/convex/utils/cache.ts
+++ b/convex/utils/cache.ts
@@ -1,0 +1,34 @@
+import { internal } from "../_generated/api";
+import type { ActionCtx } from "../_generated/server";
+import type { TopicKey } from "../constants";
+
+/** Option lists for a finished year barely move; a day is plenty. */
+export const OPTIONS_TTL_MS = 24 * 60 * 60 * 1000;
+
+/** Refresh the IGDB token this far before it actually expires. */
+export const TOKEN_TTL_SKEW_MS = 5 * 60 * 1000;
+
+export function optionsKey(topic: TopicKey, year: string) {
+  return `options:${topic}:${year}`;
+}
+
+export const IGDB_TOKEN_KEY = "igdb:access-token";
+
+/** The cached value for `key`, or `null` when absent or expired. */
+export async function readCache<T>(ctx: ActionCtx, key: string): Promise<T | null> {
+  return (await ctx.runQuery(internal.cache.read, { key })) as T | null;
+}
+
+/** Convex caps a document at 1MB; a payload over this is served but not cached. */
+const MAX_CACHED_BYTES = 900_000;
+
+/**
+ * Store `value` under `key` for `ttlMs`. Caching is best-effort: an expired TTL
+ * or an oversized payload is skipped rather than failing the caller's fetch.
+ */
+export async function writeCache(ctx: ActionCtx, key: string, value: unknown, ttlMs: number) {
+  if (ttlMs <= 0) return;
+  if (JSON.stringify(value).length > MAX_CACHED_BYTES) return;
+
+  await ctx.runMutation(internal.cache.write, { key, value, expiresAt: Date.now() + ttlMs });
+}

--- a/convex/utils/cache.ts
+++ b/convex/utils/cache.ts
@@ -8,7 +8,8 @@ export const OPTIONS_TTL_MS = 24 * 60 * 60 * 1000;
 /** Refresh the IGDB token this far before it actually expires. */
 export const TOKEN_TTL_SKEW_MS = 5 * 60 * 1000;
 
-export function optionsKey(topic: TopicKey, year: string) {
+/** `year` is the parsed number, so `2025` and `02025` share one row. */
+export function optionsKey(topic: TopicKey, year: number) {
   return `options:${topic}:${year}`;
 }
 
@@ -27,8 +28,13 @@ const MAX_CACHED_BYTES = 900_000;
  * or an oversized payload is skipped rather than failing the caller's fetch.
  */
 export async function writeCache(ctx: ActionCtx, key: string, value: unknown, ttlMs: number) {
-  if (ttlMs <= 0) return;
-  if (JSON.stringify(value).length > MAX_CACHED_BYTES) return;
+  // Negated so a NaN ttl (a third-party response missing its expiry) is skipped
+  // too — it would otherwise store an `expiresAt` no comparison ever expires.
+  if (!(ttlMs > 0)) return;
+
+  const serialized = JSON.stringify(value);
+  if (serialized === undefined) return;
+  if (new TextEncoder().encode(serialized).length > MAX_CACHED_BYTES) return;
 
   await ctx.runMutation(internal.cache.write, { key, value, expiresAt: Date.now() + ttlMs });
 }

--- a/convex/utils/dates.ts
+++ b/convex/utils/dates.ts
@@ -1,10 +1,22 @@
 const START_YEAR = 1987;
 
-export function currentYear(yearString: string) {
+/**
+ * The year arg as a number, rejecting anything outside the range the year picker
+ * offers. Every option action runs this before it builds a cache key or a
+ * third-party URL, so the key space stays bounded and nothing caller-controlled
+ * reaches the URL.
+ */
+export function parseYear(yearString: string) {
   const year = parseInt(yearString, 10);
   if (isNaN(year) || year < START_YEAR || year > new Date().getFullYear())
-    // internal: plain Error — year is validated by the arg validator upstream
+    // internal: plain Error — nothing user-actionable; the picker only offers valid years
     throw new Error("Invalid year");
+
+  return year;
+}
+
+export function currentYear(yearString: string) {
+  const year = parseYear(yearString);
   const startDate = new Date(year, 0, 1).getTime() / 1000;
   const endDate = new Date(year + 1, 0, 1).getTime() / 1000;
 


### PR DESCRIPTION
## Summary

`getMovies`/`getGames`/`getBooks` were public Convex actions: anyone with the deployment URL could burn TMDB/IGDB quota and Convex action minutes, up to five sequential TMDB calls or a fresh Twitch OAuth token per call. This PR adds an auth + per-user rate-limit guard, a 24h `(topic, year)` result cache, and a cached Twitch token so repeat option loads no longer hit third-party APIs.

Closes #81

## Changes

- `convex/utils/auth.ts` — `requireOptionsAccess`: auth check then a per-user token-bucket rate limit (10/min per action). No membership check — options are picked before a session exists.
- `convex/ratelimits.ts` — registers the three option-action rate-limit buckets.
- `convex/schema.ts` — new `apiCache` table (`key`/`value`/`expiresAt`, `by_key` index), one row per key.
- `convex/cache.ts`, `convex/utils/cache.ts` — internal read/write for `apiCache` and a `getOrFetch`-style cache helper; caching is best-effort (a payload over 900KB is served but not written, so a large IGDB response can't fail the fetch).
- `convex/utils/dates.ts` — `parseYear` extracted from `currentYear`; validates the year is a real number in the picker's range.
- `convex/tmdb.ts`, `convex/openlibrary.ts`, `convex/igdb.ts` — `getMovies`/`getBooks`/`getGames` now call `requireOptionsAccess`, validate `year` via `parseYear` before building any cache key or third-party URL, and cache results per `(topic, parsed year)` for 24h.
- `convex/igdb.ts` — Twitch token cached for its `expires_in` minus a 5min skew; `getAccessToken(ctx, refresh)` mints and overwrites the cached token, and `getGames` retries once on a 401 so a rotated `IGDB_CLIENT_SECRET` self-heals instead of wedging until the ~60-day TTL lapses.
- `convex/reset.ts` — `apiCache` added to the dev-only `reset.clearAll` wipe list.
- `convex/constants.ts` — new constants (cache TTL, token skew, size ceiling).
- `convex/_generated/api.d.ts` — hand-edited, see Notes below.
- `convex/__tests__/options.test.ts` — new: unauthenticated/rate-limited/invalid-year negative cases; cache hits per year and across year spellings; Twitch token reuse, 401-retry, and no-expiry non-caching; oversized-payload serve-without-cache; expired-entry refetch.

## Verification

`bun run check:format && bun run check:lint && bun run check:types && bun test` all pass (78 tests, 0 fail) per gate.log. `bun run test:web` (Playwright, 17 tests) also passed.

Review flagged five findings (`findings-1.json`, verdict `request_changes`); fix-report.md disposition:

- **fixed** — `year` was an unvalidated `v.string()`, making the cache key fully caller-controlled (unbounded rows) and letting `getMovies`/`getBooks` interpolate a raw string into the third-party URL unencoded. Now validated via `parseYear` before any cache key or URL is built; `2025`/`02025` share one cache row.
- **fixed** — the Twitch token was cached for its full ~60-day `expires_in` with no invalidate-and-retry on 401, so a rotated `IGDB_CLIENT_SECRET` would wedge `getGames` until the TTL lapsed with no way to clear it on prod. Now retries once on 401 with a freshly minted token.
- **fixed** — the 900KB cache-write ceiling was measured in UTF-16 code units (`.length`) rather than bytes, and `JSON.stringify(undefined)` would throw; now measured with `TextEncoder` and a stringify-to-`undefined` skips the write.
- **fixed** — the TTL guard (`ttlMs <= 0`) didn't catch `NaN`, so a Twitch response missing `expires_in` would cache a token with `expiresAt: NaN` that never expires; guard is now `!(ttlMs > 0)`.
- **skipped** — the rate-limit sizing note: `retry: 2` in `src/main.tsx` means an options load can cost up to 3 tokens of the 10/min bucket, and a rate-limit rejection is itself retried. Accurate, no code defect — resizing the bucket or exempting `RateLimited` from client retries is a product call left for the human; nothing is broken today since the server cache absorbs repeats.

## Notes for reviewer

- `convex/_generated/api.d.ts` is hand-edited (two module entries, in codegen's emit order) — `bunx convex codegen` needs deployment network access the sandbox denies; re-running it locally should be a no-op. Worth a quick diff-check against a real codegen run before merge.
- Schema change: new `apiCache` table. Writes overwrite per key, so the table stays bounded (topics × offered years, plus the token) and needs no sweeper — this claim was the first review finding, now backed by the `parseYear` validation.
- Start review at `convex/utils/auth.ts` (the guard) and `convex/__tests__/options.test.ts` (coverage for every finding above).
- The skipped rate-limit-sizing item above is a live decision, not a defect — flagging for Ryan's call on bucket size vs. client retry behavior.
- No new dependencies.
