### PR TITLE
chore(e2e): cover reveal timeout, closed sessions, name, rate limit and option failure

### DIFF
--- a/playwright/game/reveal-timeout.e2e.ts
+++ b/playwright/game/reveal-timeout.e2e.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "@playwright/test";
+
+import { createSession } from "../helpers/session";
+
+// Every other reveal spec clicks `reveal-skip`, so the scheduled
+// `internal.rounds.completeReveal` job never runs end to end. Here the host
+// leaves it alone: a one-player session reveals for playerCount * 4s + 5s = 9s
+// (convex/rounds.ts), well inside the 30s test timeout.
+test("reveal: the scheduled job advances the round when the host never skips", async ({ page }) => {
+  await createSession(page, "Host");
+
+  await page.getByTestId("lobby-start").click();
+  await expect(page.getByText("Round 10")).toBeVisible();
+
+  // Submitting the only pick closes the round and schedules the reveal.
+  await page.getByTestId("pick-input").fill("a");
+  await expect(page.getByTestId("suggestion-item").first()).toBeVisible();
+  await page.getByTestId("suggestion-item").first().click();
+  await expect(page.getByTestId("submit-pick")).toBeEnabled();
+  await page.getByTestId("submit-pick").click();
+
+  await expect(page.getByTestId("reveal-container")).toBeVisible();
+  await expect(page.getByTestId("reveal-skip")).toBeVisible();
+
+  // The countdown bar fills over the server's reveal window, so its width grows
+  // while the reveal is in play.
+  const countdown = page.getByTestId("reveal-countdown");
+  await expect(countdown).toBeVisible();
+  const startWidth = (await countdown.boundingBox())?.width ?? 0;
+  await expect
+    .poll(async () => (await countdown.boundingBox())?.width ?? 0, { timeout: 5_000 })
+    .toBeGreaterThan(startWidth);
+
+  // No skip click anywhere in this spec — the scheduled job does the advancing.
+  await expect(page.getByText("Round 9")).toBeVisible();
+  await expect(page.getByTestId("reveal-container")).toHaveCount(0);
+  await expect(page.getByTestId("pick-input")).toBeVisible();
+});

--- a/playwright/helpers/session.ts
+++ b/playwright/helpers/session.ts
@@ -1,0 +1,27 @@
+import { expect, type Page } from "@playwright/test";
+
+/**
+ * Creates a session through the UI — there is no server-side seed for it — and
+ * returns the session ID the lobby shows. The page is left in the lobby.
+ */
+export async function createSession(page: Page, name: string) {
+  await page.goto("/");
+  await page.getByTestId("home-start").click();
+  await page.getByTestId("name-input").pressSequentially(name);
+  await expect(page.getByTestId("setup-submit")).toBeEnabled();
+  await page.getByTestId("setup-submit").click();
+
+  await expect(page.getByTestId("lobby-start")).toBeVisible();
+  const sessionId = await page.getByTestId("session-id").getAttribute("data-value");
+  if (!sessionId) throw new Error("Could not read session ID");
+  return sessionId;
+}
+
+/** Joins an open lobby through the UI and waits for the joined state. */
+export async function joinLobby(page: Page, sessionId: string, name: string) {
+  await page.goto(`/games/2026/${sessionId}`);
+  await page.getByTestId("name-input").fill(name);
+  await expect(page.getByTestId("setup-submit")).toBeEnabled();
+  await page.getByTestId("setup-submit").click();
+  await expect(page.getByTestId("leave-lobby")).toBeVisible();
+}

--- a/playwright/pregame/error.e2e.ts
+++ b/playwright/pregame/error.e2e.ts
@@ -1,19 +1,32 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
-test("error: invalid session ID shows error or join form", async ({ page }) => {
-  await page.goto("/games/2026/invalid-session-id");
+// A session ID that is not a well-formed Convex ID fails the `v.id("sessions")`
+// validator in `getSession`, so the query throws and the root ErrorBoundary
+// renders `DisplayError` with its Retry button. The join form must not appear:
+// there is no session to join.
+async function expectSessionIdRejected(page: Page, sessionId: string) {
+  await page.goto(`/games/2026/${sessionId}`);
 
-  // Page should load without crashing — either error state or join form renders
-  await expect(
-    page.getByText("Something went wrong").or(page.getByTestId("name-input")),
-  ).toBeVisible({ timeout: 15000 });
+  await expect(page.getByTestId("error-state")).toBeVisible();
+  await expect(page.getByText("Something went wrong")).toBeVisible();
+  await expect(page.getByTestId("error-retry")).toBeVisible();
+  await expect(page.getByTestId("name-input")).toHaveCount(0);
+  await expect(page.getByTestId("session-id")).toHaveCount(0);
+}
+
+test("error: a malformed session ID shows the error state, not the join form", async ({ page }) => {
+  await expectSessionIdRejected(page, "invalid-session-id");
 });
 
-test("error: nonexistent session ID shows error or join form", async ({ page }) => {
-  // Use a plausible but nonexistent ID
-  await page.goto("/games/2026/j57d9pf2p0vabcdefgh1234");
-
-  await expect(
-    page.getByText("Something went wrong").or(page.getByTestId("name-input")),
-  ).toBeVisible({ timeout: 15000 });
+test("error: a well-formed but invalid session ID shows the error state, not the join form", async ({
+  page,
+}) => {
+  // Convex IDs carry a checksum, so a hand-written ID of the right shape is
+  // rejected by the validator exactly like the malformed one above — the client
+  // never gets as far as a "session not found" read. The remaining case, a
+  // genuine ID whose session row is gone (`Lobby`'s `if (!session)`), is not
+  // reachable from a spec today: nothing deletes a single session, and
+  // `/test/cleanup` wipes the whole deployment, which would break the specs
+  // sharing it under CI's four workers.
+  await expectSessionIdRejected(page, "j57d9pf2p0vabcdefgh1234");
 });

--- a/playwright/pregame/identity.e2e.ts
+++ b/playwright/pregame/identity.e2e.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/test";
+
+import { createSession, joinLobby } from "../helpers/session";
+
+test("identity: a reload and a second tab keep the same anonymous player", async ({ browser }) => {
+  const hostContext = await browser.newContext();
+  const hostPage = await hostContext.newPage();
+  const sessionId = await createSession(hostPage, "Host");
+
+  const guestContext = await browser.newContext();
+  const guestPage = await guestContext.newPage();
+  await joinLobby(guestPage, sessionId, "Guest");
+
+  await expect(hostPage.getByText("Guest")).toBeVisible();
+  await expect(hostPage.getByTestId("player-count")).toHaveText("2 of 10");
+
+  // Reload: the stored anonymous identity is recognised, so no join form.
+  await guestPage.reload();
+  await expect(guestPage.getByTestId("leave-lobby")).toBeVisible();
+  await expect(guestPage.getByTestId("name-input")).toHaveCount(0);
+
+  // A second tab of the same context is the same player, not a new one.
+  const secondTab = await guestContext.newPage();
+  await secondTab.goto(`/games/2026/${sessionId}`);
+  await expect(secondTab.getByTestId("leave-lobby")).toBeVisible();
+  await expect(secondTab.getByTestId("name-input")).toHaveCount(0);
+  await expect(hostPage.getByTestId("player-count")).toHaveText("2 of 10");
+
+  await secondTab.close();
+  await hostContext.close();
+  await guestContext.close();
+});
+
+test("identity: a player who leaves can rejoin the same lobby", async ({ browser }) => {
+  const hostContext = await browser.newContext();
+  const hostPage = await hostContext.newPage();
+  const sessionId = await createSession(hostPage, "Host");
+
+  const guestContext = await browser.newContext();
+  const guestPage = await guestContext.newPage();
+  await joinLobby(guestPage, sessionId, "Guest");
+  await expect(hostPage.getByTestId("player-count")).toHaveText("2 of 10");
+
+  await guestPage.getByTestId("leave-lobby").click();
+  await expect(guestPage).toHaveURL("/");
+  await expect(hostPage.getByTestId("player-count")).toHaveText("1 of 10");
+
+  // Same browser context, same identity, new player row under a new name.
+  await joinLobby(guestPage, sessionId, "Rejoiner");
+
+  await expect(hostPage.getByText("Rejoiner")).toBeVisible();
+  await expect(hostPage.getByText("Guest", { exact: true })).toHaveCount(0);
+  await expect(hostPage.getByTestId("player-count")).toHaveText("2 of 10");
+
+  await hostContext.close();
+  await guestContext.close();
+});

--- a/playwright/pregame/join-closed.e2e.ts
+++ b/playwright/pregame/join-closed.e2e.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "@playwright/test";
+
+import { createSession } from "../helpers/session";
+
+test("join: a newcomer opening an active session lands on the error state", async ({ browser }) => {
+  const hostContext = await browser.newContext();
+  const hostPage = await hostContext.newPage();
+
+  const sessionId = await createSession(hostPage, "Host");
+  await hostPage.getByTestId("lobby-start").click();
+  await expect(hostPage.getByTestId("pick-input")).toBeVisible();
+
+  const guestContext = await browser.newContext();
+  const guestPage = await guestContext.newPage();
+  await guestPage.goto(`/games/2026/${sessionId}`);
+
+  // The lobby redirects anyone opening an active session to the round in play,
+  // where the member-only round queries throw for a non-member.
+  await expect(guestPage).toHaveURL(`/games/2026/${sessionId}/10`);
+  await expect(guestPage.getByTestId("error-state")).toBeVisible();
+  await expect(guestPage.getByTestId("name-input")).toHaveCount(0);
+  await expect(guestPage.getByTestId("pick-input")).toHaveCount(0);
+
+  await hostContext.close();
+  await guestContext.close();
+});
+
+test("join: a newcomer opening an ended session is sent home", async ({ browser }) => {
+  const hostContext = await browser.newContext();
+  const hostPage = await hostContext.newPage();
+
+  const sessionId = await createSession(hostPage, "Host");
+  await hostPage.getByTestId("lobby-start").click();
+  await expect(hostPage.getByTestId("pick-input")).toBeVisible();
+
+  // "Leave Game" ends the session outright when the host is the one leaving.
+  await hostPage.getByTestId("settings-button").click();
+  await hostPage.getByTestId("leave-game").click();
+  await expect(hostPage).toHaveURL("/");
+
+  const guestContext = await browser.newContext();
+  const guestPage = await guestContext.newPage();
+  await guestPage.goto(`/games/2026/${sessionId}`);
+
+  await expect(guestPage.getByTestId("toast")).toContainText("The host ended the game.");
+  await expect(guestPage).toHaveURL("/");
+  await expect(guestPage.getByTestId("home-start")).toBeVisible();
+  await expect(guestPage.getByTestId("name-input")).toHaveCount(0);
+
+  await hostContext.close();
+  await guestContext.close();
+});

--- a/playwright/pregame/name-validation.e2e.ts
+++ b/playwright/pregame/name-validation.e2e.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "@playwright/test";
+
+import { createSession } from "../helpers/session";
+
+test("join: an empty or disallowed name keeps the join button disabled", async ({ browser }) => {
+  const hostContext = await browser.newContext();
+  const hostPage = await hostContext.newPage();
+  const sessionId = await createSession(hostPage, "Host");
+
+  const guestContext = await browser.newContext();
+  const guestPage = await guestContext.newPage();
+  await guestPage.goto(`/games/2026/${sessionId}`);
+
+  // A valid name first: the button is disabled while the options load too, so
+  // without this the assertions below could pass for the wrong reason.
+  await guestPage.getByTestId("name-input").fill("Guest");
+  await expect(guestPage.getByTestId("setup-submit")).toBeEnabled();
+
+  await guestPage.getByTestId("name-input").fill("");
+  await expect(guestPage.getByTestId("setup-submit")).toBeDisabled();
+
+  await guestPage.getByTestId("name-input").fill("Bob!");
+  await expect(guestPage.getByTestId("setup-submit")).toBeDisabled();
+  await expect(
+    guestPage.getByText("Only letters, numbers, spaces, hyphens, and periods allowed"),
+  ).toBeVisible();
+
+  // Nobody joined.
+  await expect(hostPage.getByTestId("player-count")).toHaveText("1 of 10");
+
+  await hostContext.close();
+  await guestContext.close();
+});
+
+test("join: the name field stops accepting input at the server's max length", async ({ page }) => {
+  await page.goto("/games/2026");
+
+  await page.getByTestId("name-input").pressSequentially("abcdefghijklmnopqrstuvwxyz");
+
+  // MAX_NAME_LENGTH is 20 (convex/utils/validate.ts): the field drops the last
+  // six characters, so the over-length name never reaches the server.
+  await expect(page.getByTestId("name-input")).toHaveValue("abcdefghijklmnopqrst");
+  await expect(page.getByTestId("setup-submit")).toBeEnabled();
+});
+
+test("join: whitespace-only and duplicate names are accepted today", async ({ browser }) => {
+  const hostContext = await browser.newContext();
+  const hostPage = await hostContext.newPage();
+  const sessionId = await createSession(hostPage, "Twin");
+
+  // The ticket expected a whitespace-only name to be blocked. It is not:
+  // `validateName` only screens characters and length, `joinSession` adds
+  // nothing, and the button's `name.length < 1` check counts spaces — so "   "
+  // joins and takes a nameless row in the lobby. No duplicate-name check exists
+  // either. This spec pins the behaviour that ships rather than asserting a
+  // block that does not exist; adding the validation is a product change this
+  // ticket does not ask for — see the PR notes.
+  const blankContext = await browser.newContext();
+  const blankPage = await blankContext.newPage();
+  await blankPage.goto(`/games/2026/${sessionId}`);
+  await blankPage.getByTestId("name-input").fill("   ");
+  await expect(blankPage.getByTestId("setup-submit")).toBeEnabled();
+  await blankPage.getByTestId("setup-submit").click();
+  await expect(blankPage.getByTestId("leave-lobby")).toBeVisible();
+
+  const twinContext = await browser.newContext();
+  const twinPage = await twinContext.newPage();
+  await twinPage.goto(`/games/2026/${sessionId}`);
+  await twinPage.getByTestId("name-input").fill("Twin");
+  await expect(twinPage.getByTestId("setup-submit")).toBeEnabled();
+  await twinPage.getByTestId("setup-submit").click();
+  await expect(twinPage.getByTestId("leave-lobby")).toBeVisible();
+  await expect(twinPage.getByTestId("toast")).toHaveCount(0);
+
+  await expect(hostPage.getByText("Twin", { exact: true })).toHaveCount(2);
+  await expect(hostPage.getByTestId("player-count")).toHaveText("3 of 10");
+
+  await hostContext.close();
+  await blankContext.close();
+  await twinContext.close();
+});

--- a/playwright/pregame/option-failure.e2e.ts
+++ b/playwright/pregame/option-failure.e2e.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@playwright/test";
+
+import { createSession } from "../helpers/session";
+
+// The option actions run `parseYear` before they reach fixtures or a third-party
+// call, so a year outside the picker's range makes `getGames` throw for the same
+// reason an IGDB outage would: the action rejects and TanStack Query gives up
+// after its retries. Fixtures can't fail, and the action travels over the Convex
+// WebSocket, so `page.route()` can't fail it either.
+const FAILING_YEAR = "1900";
+
+test("options: a failing option fetch replaces the join screen with the error state", async ({
+  page,
+}) => {
+  await page.goto(`/games/${FAILING_YEAR}`);
+
+  await expect(page.getByTestId("error-state")).toBeVisible();
+  await expect(page.getByText("Something went wrong")).toBeVisible();
+  await expect(page.getByTestId("error-retry")).toBeVisible();
+  await expect(page.getByTestId("name-input")).toHaveCount(0);
+});
+
+test("options: a failing option fetch replaces the round screen with the error state", async ({
+  page,
+}) => {
+  const sessionId = await createSession(page, "Host");
+
+  await page.getByTestId("lobby-start").click();
+  await expect(page.getByTestId("pick-input")).toBeVisible();
+
+  // Same session and round, options that cannot load.
+  await page.goto(`/games/${FAILING_YEAR}/${sessionId}/10`);
+
+  await expect(page.getByTestId("error-state")).toBeVisible();
+  await expect(page.getByTestId("error-retry")).toBeVisible();
+  // The ticket expected the pick input to stay usable through an option outage.
+  // It does not: `throwOnError` in src/queries/use-games.ts sends the failure to
+  // the root ErrorBoundary, so the whole round screen is replaced. This asserts
+  // what ships; whether the app should degrade more gently is a call for the
+  // reviewer — see the PR notes.
+  await expect(page.getByTestId("pick-input")).toHaveCount(0);
+});

--- a/playwright/pregame/rate-limit.e2e.ts
+++ b/playwright/pregame/rate-limit.e2e.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "@playwright/test";
+
+// `createSession` allows 5 calls a minute per user (convex/ratelimits.ts).
+// Failed mutations roll their token consumption back with the rest of the
+// transaction, so a bucket only empties on calls that succeed: this spec creates
+// its allowance of sessions and then asks for one more.
+const ALLOWANCE = 5;
+
+test("rate limit: exceeding the create bucket surfaces the limit in a toast", async ({ page }) => {
+  for (let i = 0; i < ALLOWANCE; i++) {
+    await page.goto("/games/2026");
+    await page.getByTestId("name-input").fill(`Host ${i}`);
+    await expect(page.getByTestId("setup-submit")).toBeEnabled();
+    await page.getByTestId("setup-submit").click();
+    await expect(page.getByTestId("lobby-start")).toBeVisible();
+  }
+
+  await page.goto("/games/2026");
+  await page.getByTestId("name-input").fill("One Too Many");
+  await expect(page.getByTestId("setup-submit")).toBeEnabled();
+  await page.getByTestId("setup-submit").click();
+
+  // The rate limiter's message, not a silent failure or the generic fallback.
+  await expect(page.getByTestId("toast")).toContainText("Slow down and try again");
+
+  // Rejected: still on the topic screen, no session created.
+  await expect(page.getByTestId("name-input")).toBeVisible();
+  await expect(page.getByTestId("lobby-start")).toHaveCount(0);
+});

--- a/playwright/pregame/session-full.e2e.ts
+++ b/playwright/pregame/session-full.e2e.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "@playwright/test";
+
+import { MAX_PLAYERS } from "convex/constants";
+
+import { addPlayer } from "../helpers/convex";
+import { createSession } from "../helpers/session";
+
+test("join: a full session rejects the newcomer with the server's error", async ({ browser }) => {
+  const hostContext = await browser.newContext();
+  const hostPage = await hostContext.newPage();
+
+  const sessionId = await createSession(hostPage, "Host");
+
+  // The host holds the first seat; seed the rest so the lobby is at the cap.
+  for (let i = 2; i <= MAX_PLAYERS; i++) {
+    await addPlayer({ sessionId, name: `Player ${i}`, avatar: "🎮" });
+  }
+  await expect(hostPage.getByText(`${MAX_PLAYERS} of ${MAX_PLAYERS}`)).toBeVisible();
+
+  const guestContext = await browser.newContext();
+  const guestPage = await guestContext.newPage();
+
+  await guestPage.goto(`/games/2026/${sessionId}`);
+  await guestPage.getByTestId("name-input").fill("Latecomer");
+  await expect(guestPage.getByTestId("setup-submit")).toBeEnabled();
+  await guestPage.getByTestId("setup-submit").click();
+
+  await expect(guestPage.getByTestId("toast")).toContainText("Session is full");
+
+  // Rejected: still on the join form, and never listed in the host's lobby.
+  await expect(guestPage.getByTestId("name-input")).toBeVisible();
+  await expect(guestPage.getByTestId("leave-lobby")).toHaveCount(0);
+  await expect(hostPage.getByText("Latecomer")).toHaveCount(0);
+  await expect(hostPage.getByText(`${MAX_PLAYERS} of ${MAX_PLAYERS}`)).toBeVisible();
+
+  await hostContext.close();
+  await guestContext.close();
+});

--- a/src/components/states/error.tsx
+++ b/src/components/states/error.tsx
@@ -10,11 +10,14 @@ interface Props {
 
 export function DisplayError({ message = "Something went wrong", onRetry }: Props) {
   return (
-    <div className="flex flex-1 flex-row items-center justify-center gap-lg px-lg">
+    <div
+      data-testid="error-state"
+      className="flex flex-1 flex-row items-center justify-center gap-lg px-lg"
+    >
       <Avatar source={SAD_ROBOT} size={80} />
       <div className="flex shrink flex-col gap-md">
         <p className="font-medium text-lg text-black-100">{message}</p>
-        {onRetry ? <Button label="Retry" onClick={onRetry} /> : null}
+        {onRetry ? <Button testID="error-retry" label="Retry" onClick={onRetry} /> : null}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Closes the e2e coverage gaps from the audit: one spec per gap, all driven through `getByTestId` rather than text/role selectors. New specs cover a single-player reveal that times out and advances via the scheduled `completeReveal` job with no skip click, a full session rejecting a newcomer, a newcomer hitting a closed (active or ended) session, name validation (empty/disallowed/over-length/whitespace/duplicate), the create-session rate-limit toast, a failing option fetch replacing the join/round screens with the error state, and identity persistence across reload/second-tab/leave-rejoin. The shared UI-driven session setup (`createSession`/`joinLobby`) now lives in `playwright/helpers/session.ts`. `DisplayError` gained `data-testid="error-state"` and `testID="error-retry"` so the new specs can assert the failure state without text matching.

Closes #85

## Changes

- `playwright/game/reveal-timeout.e2e.ts` — single-player reveal (9s) advances on the scheduled `completeReveal` job with no skip click, countdown bar filling as it goes.
- `playwright/pregame/session-full.e2e.ts` — lobby seeded to `MAX_PLAYERS`, join rejected with "Session is full".
- `playwright/pregame/join-closed.e2e.ts` — newcomer on an ACTIVE session is redirected to the round and hits the error state; on an ENDED session is sent home with the host-ended toast.
- `playwright/pregame/name-validation.e2e.ts` — empty and disallowed-character names keep the join button disabled, the field truncates at `MAX_NAME_LENGTH`; whitespace-only and duplicate names are asserted as accepted today (see Notes).
- `playwright/pregame/rate-limit.e2e.ts` — exhausts the create-session bucket, asserts the "Slow down and try again" toast.
- `playwright/pregame/option-failure.e2e.ts` — a year outside the picker's range fails `getGames`, replacing the join and round screens with the error state.
- `playwright/pregame/identity.e2e.ts` — reload, second tab and leave-then-rejoin keep one anonymous player.
- `playwright/pregame/error.e2e.ts` — both a malformed and a well-formed-but-invalid session ID assert the error state and the absence of a join form (renamed from "unknown session ID" — see Notes).
- `playwright/helpers/session.ts` — new `createSession`/`joinLobby` helpers, shared by the six new specs (the older specs still inline their own copies).
- `src/components/states/error.tsx` — adds `data-testid="error-state"` and `testID="error-retry"` so specs can assert the failure state via test ID.

## Verification

Per `gate.log`: `oxfmt --check`, `oxlint`, `bunx tsc --noEmit`, and `bun test` (105 unit tests) all clean. `bunx playwright test` (`bun run test:web`) ran the full suite green: 29/29 passed, including all seven new specs and the extracted helper.

The reviewer flagged four things; per `fix-report.md`:
- `option-failure.e2e.ts:43` — held. Spec asserts what ships (`throwOnError` in `use-games.ts` sends the failure to the root `ErrorBoundary`, blanking the whole round screen), not the ticket's ask that the pick input stay usable. No behaviour change made — see Notes.
- `name-validation.e2e.ts:57` — held. Spec pins that a whitespace-only name joins today (`validateName` doesn't screen spaces, the button check is `name.length < 1`), rather than asserting the block the ticket asked for. No behaviour change made — see Notes.
- `error.e2e.ts:21` — partial. Renamed the test off "unknown session ID" since both IDs fail the same `v.id("sessions")` validator; the case the ticket actually names (a well-formed ID with no session behind it) is still uncovered — see Notes.
- `identity.e2e.ts:3` — fixed. Extracted the copy-pasted `createSession`/`joinLobby` helper into `playwright/helpers/session.ts`, used by six specs.

## Notes for reviewer

**Two places where the app contradicts the ticket** — both are product decisions, not test decisions, so the specs pin what ships rather than what was asked for:
- Option-API outage wipes the round for everyone in it. The ticket asked the pick input to stay usable through a failed option fetch; `useTopicData` sets `throwOnError`, so the root `ErrorBoundary` replaces the whole round screen mid-game. Fix, if wanted, is a scoped error boundary or a non-throwing query — a product change this ticket doesn't ask for.
- A whitespace-only name joins the lobby. The ticket asked for it to be blocked; `validateName` only screens characters/length, `joinSession` adds nothing, and the join button's `name.length < 1` check counts spaces. No duplicate-name check exists either. Blocking this is a product change this ticket doesn't ask for.

**`error.e2e.ts` still has a coverage gap.** Both a malformed and a well-formed session ID fail Convex's `v.id("sessions")` validator identically, so the case the ticket actually names — a real ID whose session row is gone (`Lobby`'s `if (!session)`) — is untested. Covering it needs a new `/test/delete-session` HTTP endpoint (new server-side test surface); nothing currently deletes a single session, and `/test/cleanup` wipes the whole shared deployment under CI's four workers. Flagging for a human call rather than adding server surface unprompted.

Other findings that moved the plan mid-implementation, for context:
- The rate-limit spec exhausts `createSession` (5/min), not `joinSession` — a failing mutation rolls its token consumption back, so a bucket only empties on calls that succeed and repeated failed joins never reach the limit.
- Option failure is driven by a year outside the picker's range (fails `parseYear` inside `getGames`) rather than a fixture-failure switch; `page.route()` can't fail an action that travels over the Convex WebSocket.
- Convex IDs carry a checksum, so a hand-written "plausible" ID is rejected the same way a malformed one is — both error specs now assert that same contract, which is why one was renamed rather than left claiming different coverage.

`src/components/states/error.tsx` picks up two `data-testid`/`testID` attributes purely to satisfy the ticket's getByTestId-only rule — no behavioural change.

`playwright/helpers/session.ts` is new shared setup for the six new specs; the pre-existing specs (`lobby.e2e.ts`, `smoke.e2e.ts`, etc.) still inline their own copies and were left alone — converting them is outside this ticket.
