### PR TITLE
fix(round): navigate the round URL through the router

### DIFF
--- a/src/screens/round/utils/use-round-state.ts
+++ b/src/screens/round/utils/use-round-state.ts
@@ -30,8 +30,12 @@ export function useRoundState({ sessionId, topic, year }: Props) {
 
   useEffect(() => {
     if (!activeRound) return;
-    window.history.replaceState(null, "", `/${topic}/${year}/${sessionId}/${activeRound}`);
-  }, [activeRound, sessionId, topic, year]);
+    navigate({
+      to: "/$topic/$year/$sessionId/$round",
+      params: { topic, year, sessionId, round: String(activeRound) },
+      replace: true,
+    });
+  }, [activeRound, navigate, sessionId, topic, year]);
 
   useEffect(() => {
     if (activeRound === 1 && round?.state === "closed") {


### PR DESCRIPTION
## Summary

`useRoundState` advanced the round URL with a raw `window.history.replaceState` call, bypassing the router entirely. That meant back/forward navigation resolved against history entries the router never keyed, and the `$round` param the header title reads only stayed correct because @tanstack/history monkey-patches `window.history` underneath. This swaps that call for the typed `navigate({ to: "/$topic/$year/$sessionId/$round", params, replace: true })` the routing rules require, so the round URL updates through the router like every other navigation in the app.

Closes #90

## Changes

- `src/screens/round/utils/use-round-state.ts`: replace the `window.history.replaceState` call in the round-URL effect with `navigate({ to: "/$topic/$year/$sessionId/$round", params, replace: true })`, using the `useNavigate` hook already imported in this file.

## Verification

Per gate.log: `oxfmt --check`, `oxlint`, `bunx tsc --noEmit`, and `bun test` (105 pass, 0 fail) all passed. `bunx playwright test` also ran and passed (29/29), including the round-advancement and header-title-covering specs.

The review (findings-1.json) returned an empty finding set with an "approve" verdict: confirmed the effect is single-file/in-scope, `navigate`'s identity is stable so the effect can't loop, the route component is keyed by routeId (not params) so the "screen stays mounted across rounds" assumption in `round.tsx:60` still holds, and the params object is built correctly. No fix pass ran — there was nothing to fix.

## Notes for reviewer

Everything is in the single changed effect in `use-round-state.ts`. No new dependencies, no `.github/**` or `.claude/**` changes, no regenerated files.

No test was added for this change. Per the implement commit's body: it's a single effect in a React hook, the repo has no hook-render test setup, and adding one would mean pulling in `@testing-library/react`, which the ticket didn't call for.

The commit body also notes the Playwright suite couldn't be run in the implementer's sandbox (dev server couldn't bind :5173), so CI/this gate run is the first place it actually exercised the change — and per gate.log above, it did run here and passed.
