### PR TITLE
fix(ui): toast kick failures instead of firing the mutation and forgetting

### DIFF
--- a/src/screens/lobby/lobby.tsx
+++ b/src/screens/lobby/lobby.tsx
@@ -67,8 +67,13 @@ export function Lobby({ topic, year, sessionId }: LobbyProps) {
     toast.show({ message: "Invite link copied!", variant: "success" });
   };
 
-  const onKick = (uid: string) => {
-    if (isHost) kickFromLobby({ sessionId, uid });
+  const onKick = async (uid: string) => {
+    if (!isHost) return;
+    const { error } = await tryCatch(kickFromLobby({ sessionId, uid }));
+    if (error) {
+      Sentry.captureException(error);
+      toast.show({ message: getApiError(error).message, variant: "error" });
+    }
   };
 
   return (

--- a/src/screens/settings.tsx
+++ b/src/screens/settings.tsx
@@ -61,9 +61,12 @@ export function Settings({ sessionId, round }: Props) {
     navigate({ to: "/", replace: true });
   };
 
-  const onKick = (uid: string) => {
-    if (isHost) {
-      kickFromGame({ sessionId, uid });
+  const onKick = async (uid: string) => {
+    if (!isHost) return;
+    const { error } = await tryCatch(kickFromGame({ sessionId, uid }));
+    if (error) {
+      Sentry.captureException(error);
+      toast.show({ message: getApiError(error).message, variant: "error" });
     }
   };
 


### PR DESCRIPTION
## Summary

`settings.tsx`'s `onKick` called `kickFromGame` without awaiting it, so a rejected kick (NOT_FOUND on a player who already left, NOT_HOST, WRONG_STATE) became an unhandled promise rejection and the host saw nothing. This PR wraps it in the `tryCatch` -> `Sentry.captureException` -> `toast.show(getApiError(...).message)` contract that `sidebar-content.tsx` already uses. The ticket's other two bullets (`topic.tsx` join/create, `settings.tsx` `advanceRound`/`endSession`) were already fixed on main by prior PRs; `kickFromGame` was the only survivor. `lobby.tsx` carried the identical fire-and-forget kick and isn't named in the ticket, but it's the same bug class, so it's fixed the same way here.

Closes #88

## Changes

- `src/screens/settings.tsx`: `onKick` now awaits `kickFromGame` via `tryCatch`, reports errors to Sentry, and toasts `getApiError(error).message` on failure instead of firing and forgetting.
- `src/screens/lobby/lobby.tsx`: same fix for `onKick`/`kickFromLobby`, not named in the ticket but the identical fire-and-forget pattern.

## Verification

- `bun run check:format`, `bun run check:lint`, `bun run check:types` all pass.
- `bun test`: 113 pass, 0 fail.
- `bun run test:web` (Playwright): 29 passed, including `sidebar.e2e.ts`'s host-kicks-a-player case, which still passes against the awaited version.
- No new test was added for a kick *failure* specifically: no Convex function changed, and the reachable failure (kicking a player whose row is being removed reactively) is a race that isn't practically drivable through the UI, so an e2e for it would be flaky rather than a real guard.
- The review (verdict: approve) raised two nits; neither was a blocking finding and no fix pass ran against them — see below.

## Notes for reviewer

- Start with `lobby.tsx`'s `onKick` — it's the one change not named in the ticket's bullets. Review flagged it as beyond the ticket's enumerated scope but recommended keeping it since it's the same fire-and-forget class the ticket title calls out; leaving it unfixed would have left the bug class half open.
- Review nit (not addressed): `src/components/lists/players.tsx:26` — `PlayerList` renders the kick (✕) button whenever `onKick` is defined, and all three call sites pass it unconditionally, so a non-host sees a kick button that's now a silent no-op behind the `if (!isHost) return;` guard. Pre-existing (identical in already-merged `sidebar-content.tsx`), adjacent to this ticket's theme but out of scope for this fix; would need `onKick={isHost ? onKick : undefined}` at each call site.
- `endSession` in `settings.tsx` still navigates home on failure — that's an existing, commented decision mirrored from `sidebar-content.tsx` (the host is done with the room either way), and the ticket doesn't ask to change it.
- No new dependencies, no `.github/**` or `.claude/**` changes, nothing regenerated.
