### PR TITLE
chore(rules): move process and local-dev knowledge out of CLAUDE.md into docs/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,30 +2,29 @@
 
 Yearly-picks party game. Vite + React 19 + TanStack Router (file-based) + Convex backend + Tailwind 4. Runtime and package manager: bun.
 
-Detailed rules live in `.claude/rules/` and load when you touch matching files.
+Detailed rules live in `.claude/rules/` and load when you touch matching files. Cross-cutting changes should read both `convex.md` and `react.md`.
+
+Docs, read when relevant:
+
+- `docs/contributing.md`: branches, commits, PR process, what to disclose.
+- `docs/local-dev.md`: checks, e2e, the shared dev deployment, generated files.
+- `docs/release.md`: how releases are cut.
 
 ## Checks
 
-Run before pushing — CI enforces all four:
-
-```sh
-bun run check:format && bun run check:lint && bun run check:types && bun test
-```
-
-E2E: `bun run test:web` (Playwright, needs `.env.local`).
+CI enforces the four `check:*` / `test` scripts in `package.json`; run them before pushing. E2E is `bun run test:web` and needs `.env.local`.
 
 ## Invariants
 
-- **Disclose the unusual**: a new dependency, a CI or `.claude/` rules change, or a regenerated file gets its own line in the PR's **Notes for reviewer** saying why. A human reads every PR; make the surprising parts easy to find.
-- **Error handling in UI**: wrap every awaited Convex mutation/action call in `tryCatch` from `utils/try-catch`; on error, `Sentry.captureException(error)`, surface `error.message` via `useToast`, then early-return. Navigate/update state only on success. Never bare try/catch, never fire-and-forget mutations.
+- **Disclose the unusual**: a new dependency, a `.github/` or `.claude/` change, or a regenerated file gets its own line in the PR's **Notes for reviewer** saying why.
+- **Error handling in UI**: wrap every awaited Convex mutation/action call in `tryCatch` from `utils/try-catch`; on error, `Sentry.captureException(error)`, surface `error.message` via `useToast`, then early-return. Navigate/update state only on success. Never bare try/catch, never fire-and-forget mutations. The one exception is anonymous sign-in, where nothing can render without an identity, so the error state replaces the toast.
 - Import Sentry as a namespace (`import * as Sentry from "@sentry/react"`); it is initialized only in `services/sentry`.
 - Server-side authz **throws** — see `.claude/rules/convex.md` for the contract and the single exception.
+- The server's `session.status` decides which screen renders. Clients never navigate between game phases.
 
 ## Git
 
-- Conventional Commits: `type(scope): summary`, type ∈ `feat|fix|chore|ci`. The scope is the area touched (`convex`, `lobby`, `round`, `ci`, `deps`, `rules`), never the author or the issue number. PR titles follow the same format.
-- Branches: human work `seery/<topic>`, agent work `agent/<issue#>-<slug>`. Provenance lives in the branch name and the `Co-Authored-By` trailer, not the commit scope.
-- Rebase onto the PR's base before pushing for review. `git log --oneline <base>..HEAD` shows only this PR's commits.
-- PRs fill every section of `.github/pull_request_template.md` (Summary / Changes / Verification / Notes for reviewer) and merge to `main` via squash or rebase only.
+- `type(scope): summary`, type ∈ `feat|fix|chore|ci`, scope = area touched. PR titles too.
+- Branches: `seery/<topic>` for human work, `agent/<issue#>-<slug>` for agent work.
+- Fill every section of the PR template. `Closes #<issue>` goes in the PR **description**, one line per ticket.
 - Never add a `Claude-Session` trailer to commits or a session link to PR bodies.
-- Every PR that resolves a ticket carries `Closes #<issue>` in its **description** (not just a commit message — squash/rebase merges make the body keyword the reliable auto-close path). One line per ticket if a PR resolves several.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,57 @@
+# Contributing
+
+How a change gets from a branch to `main`. `CLAUDE.md` carries the one-line
+versions of these rules; this is the reasoning behind them.
+
+## Branches
+
+- Human work: `seery/<topic>`.
+- Agent work: `agent/<issue#>-<slug>`.
+
+Provenance lives in the branch name and the `Co-Authored-By` trailer, never in
+the commit scope. That keeps `git log` readable by area and still answers "who
+wrote this" from the PR. Never add a `Claude-Session` trailer to commits or a
+session link to PR bodies.
+
+## Commits and PR titles
+
+Conventional Commits: `type(scope): summary`, type is one of `feat`, `fix`,
+`chore`, `ci`. The scope is the area touched (`convex`, `lobby`, `round`,
+`session`, `ci`, `deps`, `rules`), never the author or the issue number. PR
+titles use the same format; `pr-title.yml` rejects anything else, and the
+release tooling reads the type to decide the version bump and changelog
+section (see `release.md`).
+
+## Before asking for review
+
+- Rebase onto the PR's base. `git log --oneline <base>..HEAD` must show only
+  this PR's commits.
+- Run the four checks and, for anything touching the app, the e2e suite (see
+  `local-dev.md`). CI enforces the checks; say in the PR what you ran.
+- Fill every section of `.github/pull_request_template.md`: Summary, Changes,
+  Verification, Notes for reviewer. A human reads every PR; the template exists
+  so the surprising parts are easy to find.
+
+## Notes for reviewer: disclose the unusual
+
+Anything a reviewer would not expect gets its own line under **Notes for
+reviewer** saying why:
+
+- a new dependency,
+- a change under `.github/**` or `.claude/**` (rules, workflows, CODEOWNERS),
+- a regenerated file (`src/routeTree.gen.ts`, `convex/_generated/**`),
+- a design token added to `src/index.css`,
+- a test that was changed rather than added.
+
+## Closing tickets
+
+Every PR that resolves a ticket carries `Closes #<issue>` in its
+**description**, one line per ticket. Commit-message keywords are not enough:
+`main` accepts only squash and rebase merges, and after either the body
+keyword is the reliable auto-close path.
+
+## Merging
+
+Squash or rebase only, into `main`, through the merge queue. The queue re-runs
+`checks` and `e2e` on its temporary branch, which is also how the release PR
+gets validated (see `release.md`).

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -1,0 +1,82 @@
+# Local development
+
+What runs where, and the things about the local setup that are not obvious
+from the code.
+
+## Checks
+
+`package.json` defines four: `check:format` (oxfmt), `check:lint` (oxlint),
+`check:types` (tsc), `test` (bun test). They run in three places:
+
+| where | what |
+| --- | --- |
+| `.husky/pre-commit` | format + lint on staged files, then `check:types` |
+| `ci.yml` `checks` job | all four, on every PR and merge-queue run |
+| you | `bun run check:format && bun run check:lint && bun run check:types && bun test` |
+
+Ignore lists live in `.oxfmtrc.json` and `.oxlintrc.json` (`ignorePatterns`,
+one per tool, which is what oxc's docs recommend; there is no shared file).
+`docs/**` is ignored by both.
+
+## E2E
+
+`bun run test:web` runs Playwright against a Vite dev server on `:5173` and
+needs `.env.local` (`CONVEX_DEPLOYMENT`, `VITE_CONVEX_URL`, `CONVEX_SITE_URL`,
+`TEST_SECRET`). Server state is seeded and cleared through the HTTP helpers
+in `playwright/helpers/convex.ts`, never through the UI.
+
+Two settings in `playwright.config.ts` matter when reading results:
+
+- `retries: 1` locally. A spec that fails once and passes on retry is reported
+  as **flaky**, and the run is green. Use `--retries 0` to see the real
+  failure rate, or read the "flaky" line rather than the exit code.
+- `reuseExistingServer` locally, so a dev server you already have on `:5173`
+  is used as is.
+
+Agent sandboxes usually cannot bind `:5173` (`listen EPERM`), so the
+pipeline's implement agent cannot run this suite. CI runs it against a
+throwaway Docker Convex backend (`ci.yml` `e2e` job).
+
+## The dev deployment is shared
+
+`bun run convex:dev`, `bunx convex dev --once`, and by extension `test:web`
+push the **current branch's** functions and schema to the one dev deployment
+named in `.env.local`. There is no per-branch backend (#154 tracks that).
+Consequences:
+
+- Any other local client of that deployment, another worktree or `main`
+  checked out elsewhere, is now on this branch's API.
+- A schema change is **refused** while stored rows violate it
+  (`Schema validation failed … Path: .status`). Rows from earlier e2e runs are
+  the usual cause. Clear them with the suite's cleanup endpoint, then push
+  again:
+
+  ```sh
+  set -a && source .env.local && set +a
+  bun -e 'import { cleanup } from "./playwright/helpers/convex"; await cleanup()'
+  bunx convex dev --once
+  ```
+
+- The local Convex CLI may rewrite `convex/_generated/server.d.ts` and
+  `server.js` on every push (it adds an `env` export the committed files lack).
+  That is CLI version drift, not part of your change; restore the files before
+  committing:
+
+  ```sh
+  git restore --source=main convex/_generated
+  ```
+
+## Generated files
+
+- `src/routeTree.gen.ts` is written by the TanStack Router Vite plugin during
+  `bun run dev` / `bun run build`. Regenerate it, never hand-edit it.
+- `convex/_generated/**` is written by the Convex CLI. Commit it only when a
+  function signature actually changed.
+
+## Auth in development
+
+Sign-in is anonymous and happens once in the `/$topic` layout via
+`hooks/use-anonymous-auth`. Every `signIn("anonymous")` call mints a new user,
+so never add a second call site; the hook's ref guard exists because
+StrictMode double-invokes effects in dev and a second sign-in replaces the
+first identity mid-flow (#155).


### PR DESCRIPTION
## Summary

`CLAUDE.md` is always-loaded context, so it should hold only the rules that shape every action and can't be read off the code. It mixed rules, rationale and process, and was missing the local-dev facts that cost real time on #153 and #157: the shared dev deployment, schema pushes refused while old rows exist, `_generated` churn from the local CLI, `retries: 1` hiding e2e flakes. This moves the process and local-dev knowledge into `docs/` with one-line pointers, drops what `package.json`, the pre-commit hook and `pr-title.yml` already enforce, and adds the two invariants that came out of this week's work.

Closes #158

## Changes

- `docs/contributing.md` (new): branches and the provenance rationale, commit/PR title format, rebase-before-review, the PR template, the full "disclose the unusual" list, why `Closes #` goes in the body, merge queue.
- `docs/local-dev.md` (new): where the four checks run (hook, CI, you); e2e prerequisites and the two Playwright settings that change how to read results; the shared dev deployment and its consequences with the cleanup + push recipe; `_generated` churn and how to restore it; generated files; anonymous auth and why there must be one call site.
- `docs/release.md`: the "repo settings" list now names both settings the workflow actually needs. Every Release run since #152 failed at startup because `googleapis/release-please-action` was not on the repo's Actions allowlist, and the "create and approve pull requests" toggle is gated at the org level first. Both are set now; the doc records them.
- `CLAUDE.md`: pointers to the three docs (including `docs/release.md`, which nothing linked to); the check block reduced to one line; the Conventional Commits elaboration reduced to one line; two invariants added (server `session.status` drives the screen; sign-in error state instead of toast); a note that cross-cutting changes read both rules files.

## Verification

- `check:format`, `check:lint`, `check:types` green. `docs/**` is in both tools' `ignorePatterns`, so the markdown is not formatted.
- Every claim in `docs/local-dev.md` was hit first-hand this week: the schema refusal and cleanup recipe on #153, the `_generated` churn on #152 and #153, the flake masking and sandbox port on #155 / #157.
- Not verified: nothing here executes, so there is nothing to run.

## Notes for reviewer

- **`CLAUDE.md` change**: this is the always-loaded instructions file, so the trimmed version is the thing to read first. Nothing was removed without either a doc pointer or an existing enforcement mechanism (`package.json` scripts, `.husky/pre-commit`, `pr-title.yml`).
- Two references assume #157 merges: `hooks/use-anonymous-auth` in `docs/local-dev.md` and the sign-in exception in the error-handling invariant. If #157 changes shape, those two lines change with it.
- The Sentry-namespace line stays as prose; turning it into a lint rule is out of scope per the ticket.
- No new dependencies, no `.github/**` or `.claude/**` changes, no regenerated files.
