### PR TITLE
chore(dev): per-checkout local Convex backend and one bun run gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ yarn-error.*
 .env
 .env*.local
 
+# local Convex backend state (binary data, admin key, per checkout)
+.convex/
+
 # Playwright
 /playwright-report/
 /test-results/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Docs, read when relevant:
 
 ## Checks
 
-CI enforces the four `check:*` / `test` scripts in `package.json`; run them before pushing. E2E is `bun run test:web` and needs `.env.local`.
+`bun run gate` before pushing: the four `check:*` / `test` scripts CI enforces, then `test:web`. E2E needs a backend — the cloud dev deployment in `.env.local`, or `bun run backend:up` for a local one (`docs/local-dev.md`).
 
 ## Invariants
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -26,8 +26,8 @@ section (see `release.md`).
 
 - Rebase onto the PR's base. `git log --oneline <base>..HEAD` must show only
   this PR's commits.
-- Run the four checks and, for anything touching the app, the e2e suite (see
-  `local-dev.md`). CI enforces the checks; say in the PR what you ran.
+- Run `bun run gate` — the four checks then the e2e suite, in one command (see
+  `local-dev.md`). CI enforces the same set; say in the PR what you ran.
 - Fill every section of `.github/pull_request_template.md`: Summary, Changes,
   Verification, Notes for reviewer. A human reads every PR; the template exists
   so the surprising parts are easy to find.

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -25,7 +25,9 @@ one per tool, which is what oxc's docs recommend; there is no shared file).
 ## E2E
 
 `bun run test:web` is `scripts/e2e.sh`. It runs Playwright against a Vite dev
-server on `:5173`, backed by whichever deployment `.env.local` names:
+server on a port of this checkout's own (`E2E_WEB_PORT`, derived from the
+checkout's path the same way the backend ports are), backed by whichever
+deployment `.env.local` names:
 
 - a cloud deployment (`CONVEX_DEPLOYMENT=dev:…`) is sourced and used as is —
   the same command this script replaced;
@@ -48,10 +50,12 @@ Two settings in `playwright.config.ts` matter when reading results:
 - `retries: 1` locally. A spec that fails once and passes on retry is reported
   as **flaky**, and the run is green. Use `--retries 0` to see the real
   failure rate, or read the "flaky" line rather than the exit code.
-- `reuseExistingServer` locally, so a dev server you already have on `:5173`
-  is used as is.
+- `reuseExistingServer`, but only when `E2E_WEB_PORT` is unset: a bare
+  `bunx playwright test` still reuses a dev server you already have on `:5173`.
+  `test:web` sets the variable to a port it claimed free, so it always starts
+  its own server rather than risk adopting another checkout's.
 
-Agent sandboxes usually cannot bind `:5173` (`listen EPERM`), so the
+Agent sandboxes usually cannot bind a Vite port (`listen EPERM`), so the
 pipeline's implement agent cannot run this suite; its gate stage runs
 `bun run gate` outside the agent, against the worktree's own local backend.
 CI runs it against a throwaway Docker Convex backend (`ci.yml` `e2e` job).
@@ -62,7 +66,8 @@ CI runs it against a throwaway Docker Convex backend (`ci.yml` `e2e` job).
 **anonymous local deployment**, a CLI-managed binary with its state under
 `.convex/` (gitignored). No cloud account, no cost, and no way for a push to
 reach anyone else's client. The script picks a port pair from the checkout's
-path so two worktrees can run at once, writes the URLs into `.env.local`, and
+path (`scripts/ports.sh`) so two worktrees can run at once, writes the URLs
+into `.env.local`, and
 sets the switches the e2e suite needs (`TEST_SECRET`, `OPTIONS_FIXTURES`, auth
 keys). After that, `convex:dev`, `dev` and `test:web` all use it with no extra
 flags. It is the pipeline's default, and optional for humans.
@@ -80,7 +85,7 @@ phone testing, the Convex dashboard. The local backend has neither.
 `bun run backend:reset` throws the instance away and rebuilds it from scratch.
 That is the way out of a push refused by rows an earlier run left behind; it
 only ever touches a local deployment, and refuses to run when `.env.local`
-names a cloud one.
+names a cloud one through either `CONVEX_DEPLOYMENT` or `VITE_CONVEX_URL`.
 
 ## The cloud dev deployment is shared
 

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -12,7 +12,11 @@ from the code.
 | --- | --- |
 | `.husky/pre-commit` | format + lint on staged files, then `check:types` |
 | `ci.yml` `checks` job | all four, on every PR and merge-queue run |
-| you | `bun run check:format && bun run check:lint && bun run check:types && bun test` |
+| you | `bun run gate` |
+
+`gate` is the one pre-PR command: the four checks in that order, then the e2e
+suite, stopping at the first failure. The pipeline's gate stage runs the same
+script, so a green `gate` locally is the same bar the agent branches clear.
 
 Ignore lists live in `.oxfmtrc.json` and `.oxlintrc.json` (`ignorePatterns`,
 one per tool, which is what oxc's docs recommend; there is no shared file).
@@ -20,10 +24,24 @@ one per tool, which is what oxc's docs recommend; there is no shared file).
 
 ## E2E
 
-`bun run test:web` runs Playwright against a Vite dev server on `:5173` and
-needs `.env.local` (`CONVEX_DEPLOYMENT`, `VITE_CONVEX_URL`, `CONVEX_SITE_URL`,
-`TEST_SECRET`). Server state is seeded and cleared through the HTTP helpers
-in `playwright/helpers/convex.ts`, never through the UI.
+`bun run test:web` is `scripts/e2e.sh`. It runs Playwright against a Vite dev
+server on `:5173`, backed by whichever deployment `.env.local` names:
+
+- a cloud deployment (`CONVEX_DEPLOYMENT=dev:…`) is sourced and used as is —
+  the same command this script replaced;
+- an anonymous one, or no `.env.local` at all, means this checkout's own local
+  backend (below): the script brings it up, pushes this branch to it, and runs
+  the suite as a child of `convex dev` so the backend is only alive for the
+  length of the run.
+
+`convex dev --start` exits 0 whenever its own push succeeded, so the script
+carries Playwright's exit status out itself. A red suite is a red `test:web`.
+
+`.env.local` needs `CONVEX_DEPLOYMENT`, `VITE_CONVEX_URL`, `CONVEX_SITE_URL`
+and `TEST_SECRET` for the cloud path; the local path writes everything but
+`TEST_SECRET` itself and the helpers fall back to `VITE_CONVEX_SITE_URL`.
+Server state is seeded and cleared through the HTTP helpers in
+`playwright/helpers/convex.ts`, never through the UI.
 
 Two settings in `playwright.config.ts` matter when reading results:
 
@@ -34,15 +52,41 @@ Two settings in `playwright.config.ts` matter when reading results:
   is used as is.
 
 Agent sandboxes usually cannot bind `:5173` (`listen EPERM`), so the
-pipeline's implement agent cannot run this suite. CI runs it against a
-throwaway Docker Convex backend (`ci.yml` `e2e` job).
+pipeline's implement agent cannot run this suite; its gate stage runs
+`bun run gate` outside the agent, against the worktree's own local backend.
+CI runs it against a throwaway Docker Convex backend (`ci.yml` `e2e` job).
 
-## The dev deployment is shared
+## Local backend (optional)
+
+`bun run backend:up` gives this checkout its own Convex backend instead: an
+**anonymous local deployment**, a CLI-managed binary with its state under
+`.convex/` (gitignored). No cloud account, no cost, and no way for a push to
+reach anyone else's client. The script picks a port pair from the checkout's
+path so two worktrees can run at once, writes the URLs into `.env.local`, and
+sets the switches the e2e suite needs (`TEST_SECRET`, `OPTIONS_FIXTURES`, auth
+keys). After that, `convex:dev`, `dev` and `test:web` all use it with no extra
+flags. It is the pipeline's default, and optional for humans.
+
+Reach for it when:
+
+- you are changing `convex/schema.ts` or a status literal, and don't want the
+  shared deployment refusing the push (below) or serving your half-migrated
+  API to someone else;
+- you want two branches checked out and testable at the same time.
+
+Stay on the cloud dev deployment for anything that needs a **public URL** —
+phone testing, the Convex dashboard. The local backend has neither.
+
+`bun run backend:reset` throws the instance away and rebuilds it from scratch.
+That is the way out of a push refused by rows an earlier run left behind; it
+only ever touches a local deployment, and refuses to run when `.env.local`
+names a cloud one.
+
+## The cloud dev deployment is shared
 
 `bun run convex:dev`, `bunx convex dev --once`, and by extension `test:web`
-push the **current branch's** functions and schema to the one dev deployment
-named in `.env.local`. There is no per-branch backend (#154 tracks that).
-Consequences:
+push the **current branch's** functions and schema to whatever `.env.local`
+names. While that is the one cloud dev deployment:
 
 - Any other local client of that deployment, another worktree or `main`
   checked out elsewhere, is now on this branch's API.
@@ -57,21 +101,19 @@ Consequences:
   bunx convex dev --once
   ```
 
-- The local Convex CLI may rewrite `convex/_generated/server.d.ts` and
-  `server.js` on every push (it adds an `env` export the committed files lack).
-  That is CLI version drift, not part of your change; restore the files before
-  committing:
-
-  ```sh
-  git restore --source=main convex/_generated
-  ```
-
 ## Generated files
 
 - `src/routeTree.gen.ts` is written by the TanStack Router Vite plugin during
   `bun run dev` / `bun run build`. Regenerate it, never hand-edit it.
 - `convex/_generated/**` is written by the Convex CLI. Commit it only when a
-  function signature actually changed.
+  function signature actually changed. Any push, cloud or local, may also
+  rewrite `server.d.ts` and `server.js` (the local CLI adds an `env` export the
+  committed files lack). That is CLI version drift (#165), not part of your
+  change; restore the files before committing:
+
+  ```sh
+  git restore --source=main convex/_generated
+  ```
 
 ## Auth in development
 

--- a/package.json
+++ b/package.json
@@ -12,10 +12,13 @@
     "check:lint": "oxlint .",
     "check:types": "bunx tsc --noEmit",
     "convex:dev": "bunx convex dev",
+    "backend:up": "scripts/backend-up.sh",
+    "backend:reset": "scripts/backend-up.sh --reset",
     "test": "bun test",
     "test:watch": "bun test --watch",
-    "test:web": "set -a && source .env.local && set +a && bunx playwright test",
-    "test:web:ui": "set -a && source .env.local && set +a && bunx playwright test --ui",
+    "test:web": "scripts/e2e.sh",
+    "test:web:ui": "scripts/e2e.sh --ui",
+    "gate": "bun run check:format && bun run check:lint && bun run check:types && bun run test && bun run test:web",
     "prepare": "husky"
   },
   "dependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,14 @@
 import { defineConfig, devices } from "@playwright/test";
 
+// `scripts/e2e.sh` sets this to a free port derived from the checkout's path.
+// Without it two checkouts running the suite at once would both want :5173 and
+// `reuseExistingServer` would hand the second one the first one's server —
+// a browser on backend A while the helpers seed backend B. The port is claimed
+// free, so there is nothing there to reuse and reuse is off; a bare
+// `bunx playwright test` keeps the old behaviour on :5173.
+const port = process.env.E2E_WEB_PORT;
+const url = `http://localhost:${port ?? 5173}`;
+
 export default defineConfig({
   globalSetup: "./playwright/helpers/global-setup.ts",
   testDir: "./playwright",
@@ -15,7 +24,7 @@ export default defineConfig({
     timeout: 15_000,
   },
   use: {
-    baseURL: "http://localhost:5173",
+    baseURL: url,
     trace: "on-first-retry",
     screenshot: "only-on-failure",
   },
@@ -26,9 +35,11 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: process.env.CI ? "bun run preview --port 5173" : "bun run dev",
-    url: "http://localhost:5173",
-    reuseExistingServer: !process.env.CI,
+    command: process.env.CI
+      ? `bun run preview --port ${port ?? 5173} --strictPort`
+      : `bun run dev --port ${port ?? 5173} --strictPort`,
+    url,
+    reuseExistingServer: !process.env.CI && !port,
     timeout: 120_000,
   },
 });

--- a/playwright/helpers/convex.ts
+++ b/playwright/helpers/convex.ts
@@ -1,4 +1,7 @@
-const siteUrl = process.env.CONVEX_SITE_URL ?? "";
+// CI and the cloud dev deployment set CONVEX_SITE_URL; the local backend writes
+// VITE_CONVEX_SITE_URL into .env.local itself, and the Convex CLI stops
+// maintaining that file if we add a second spelling to it.
+const siteUrl = process.env.CONVEX_SITE_URL ?? process.env.VITE_CONVEX_SITE_URL ?? "";
 const testSecret = process.env.TEST_SECRET ?? "";
 
 const HEADERS = {

--- a/scripts/backend-up.sh
+++ b/scripts/backend-up.sh
@@ -81,7 +81,11 @@ vars=$scratch/env-vars
 # Creates the deployment, downloads the backend binary, pins the port pair and
 # writes the URLs to .env.local. Only `convex dev` can do this — `convex env`
 # needs a deployment that already exists. Later runs reuse the saved ports.
-if [ ! -f .convex/local/default/config.json ]; then
+# Both halves have to be present: `.convex/` state without an `.env.local`
+# naming it (the file was deleted, or the checkout was copied) leaves `convex
+# env` with no deployment to talk to.
+if [ ! -f .convex/local/default/config.json ] \
+  || ! grep -qE '^CONVEX_DEPLOYMENT=anonymous:' "$ENV_FILE" 2>/dev/null; then
   claim_ports 3210 2
   bunx convex dev --once --tail-logs disable \
     --local-cloud-port "$claimed_port" --local-site-port "$((claimed_port + 1))"

--- a/scripts/backend-up.sh
+++ b/scripts/backend-up.sh
@@ -26,17 +26,27 @@ read_env() {
   grep -E "^$1=" "$ENV_FILE" | tail -1 | cut -d= -f2- || true
 }
 
+# --reset deletes $ENV_FILE, so both keys that can name a backend have to be
+# clear before we get there: a file carrying only VITE_CONVEX_URL still points
+# a client at the cloud, and still holds the reader's TEST_SECRET.
+cloud=
 deployment=$(read_env CONVEX_DEPLOYMENT)
 deployment=${deployment%%[[:space:]]#*} # the CLI writes a trailing "# team: …" comment
 case "$deployment" in
   "" | anonymous:*) ;;
-  *)
-    echo "$ENV_FILE points at $deployment, not a local backend." >&2
-    echo "Remove CONVEX_DEPLOYMENT/VITE_CONVEX_URL from $ENV_FILE and re-run," >&2
-    echo "or keep using that deployment and skip this script." >&2
-    exit 1
-    ;;
+  *) cloud=$deployment ;;
 esac
+convex_url=$(read_env VITE_CONVEX_URL)
+case "$convex_url" in
+  "" | http://127.0.0.1:* | http://localhost:* | "http://[::1]:"*) ;;
+  *) cloud=${cloud:-$convex_url} ;;
+esac
+if [ -n "$cloud" ]; then
+  echo "$ENV_FILE points at $cloud, not a local backend." >&2
+  echo "Remove CONVEX_DEPLOYMENT/VITE_CONVEX_URL from $ENV_FILE and re-run," >&2
+  echo "or keep using that deployment and skip this script." >&2
+  exit 1
+fi
 
 if [ "${1:-}" = "--reset" ]; then
   rm -rf .convex "$ENV_FILE"
@@ -48,49 +58,33 @@ fi
 test_secret=$(read_env TEST_SECRET)
 [ -n "$test_secret" ] || test_secret=$(openssl rand -hex 32)
 
-# Same ephemeral RS256 keypair the CI job mints. Rotating it just forces a new
-# anonymous sign-in.
-bun scripts/generate-test-keys.mjs
+# Templated, because BSD mktemp ignores TMPDIR without one.
+scratch=$(mktemp -d "${TMPDIR:-/tmp}/woty-backend.XXXXXX")
+trap 'rm -rf "$scratch"' EXIT
 
-vars=$(mktemp)
-trap 'rm -f "$vars"' EXIT
+# Same ephemeral RS256 keypair the CI job mints. Rotating it just forces a new
+# anonymous sign-in. Written to our own directory, not a fixed global path, so
+# a second checkout minting its own pair mid-run cannot leave us with a private
+# key and a JWKS from different keypairs.
+bun scripts/generate-test-keys.mjs "$scratch"
+
+vars=$scratch/env-vars
 {
   printf 'TEST_SECRET=%s\n' "$test_secret"
   printf 'OPTIONS_FIXTURES=1\n'
-  printf "JWT_PRIVATE_KEY='%s'\n" "$(cat /tmp/jwt-private-key.txt)"
-  printf "JWKS='%s'\n" "$(cat /tmp/jwks.json)"
+  printf "JWT_PRIVATE_KEY='%s'\n" "$(cat "$scratch/jwt-private-key.txt")"
+  printf "JWKS='%s'\n" "$(cat "$scratch/jwks.json")"
 } >"$vars"
 
-port_free() {
-  ! (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null
-}
-
-# Stable across runs so the URLs in .env.local keep working, and spread across
-# checkouts so two of them never want the same pair. Walks on if something else
-# already holds it, which is also what covers a path collision.
-SLOTS=300
-claim_ports() {
-  local seed offset i
-  seed=$(printf '%s' "$PWD" | shasum | cut -c1-4)
-  offset=$((0x$seed % SLOTS))
-  for i in $(seq 0 $((SLOTS - 1))); do
-    cloud_port=$((3210 + 2 * ((offset + i) % SLOTS)))
-    site_port=$((cloud_port + 1))
-    if port_free "$cloud_port" && port_free "$site_port"; then
-      return 0
-    fi
-  done
-  echo "No free port pair between 3210 and $((3210 + 2 * SLOTS - 1))." >&2
-  exit 1
-}
+. scripts/ports.sh
 
 # Creates the deployment, downloads the backend binary, pins the port pair and
 # writes the URLs to .env.local. Only `convex dev` can do this — `convex env`
 # needs a deployment that already exists. Later runs reuse the saved ports.
 if [ ! -f .convex/local/default/config.json ]; then
-  claim_ports
+  claim_ports 3210 2
   bunx convex dev --once --tail-logs disable \
-    --local-cloud-port "$cloud_port" --local-site-port "$site_port"
+    --local-cloud-port "$claimed_port" --local-site-port "$((claimed_port + 1))"
 fi
 
 bunx convex env set --force --from-file "$vars"

--- a/scripts/backend-up.sh
+++ b/scripts/backend-up.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Brings up this checkout's own Convex backend: an anonymous local deployment
+# (CLI-managed binary, state under ./.convex/, no cloud account, no cost) so a
+# branch's pushes can never reach the shared cloud dev deployment. Each checkout
+# gets its own instance on its own port pair, derived from its path — the CLI
+# would otherwise hand every idle checkout port 3210 and they would collide the
+# moment two ran at once.
+#
+# Idempotent. Pass --reset to throw the instance away and start clean, which is
+# the way out of a push refused by rows an earlier run left behind
+# ("Schema validation failed ... Value: ...").
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Only consulted while no deployment is configured yet: it is what stops the
+# first `convex dev` from asking a logged-in user to pick a cloud project. Once
+# .env.local names the anonymous deployment the CLI resolves it from there, so
+# nothing else in the repo has to set this.
+export CONVEX_AGENT_MODE=anonymous
+
+ENV_FILE=.env.local
+
+read_env() {
+  [ -f "$ENV_FILE" ] || return 0
+  grep -E "^$1=" "$ENV_FILE" | tail -1 | cut -d= -f2- || true
+}
+
+deployment=$(read_env CONVEX_DEPLOYMENT)
+deployment=${deployment%%[[:space:]]#*} # the CLI writes a trailing "# team: …" comment
+case "$deployment" in
+  "" | anonymous:*) ;;
+  *)
+    echo "$ENV_FILE points at $deployment, not a local backend." >&2
+    echo "Remove CONVEX_DEPLOYMENT/VITE_CONVEX_URL from $ENV_FILE and re-run," >&2
+    echo "or keep using that deployment and skip this script." >&2
+    exit 1
+    ;;
+esac
+
+if [ "${1:-}" = "--reset" ]; then
+  rm -rf .convex "$ENV_FILE"
+  echo "Discarded local backend state."
+fi
+
+# Playwright needs the same secret the deployment checks, so it outlives the
+# deployment env var. Reuse it when there is one.
+test_secret=$(read_env TEST_SECRET)
+[ -n "$test_secret" ] || test_secret=$(openssl rand -hex 32)
+
+# Same ephemeral RS256 keypair the CI job mints. Rotating it just forces a new
+# anonymous sign-in.
+bun scripts/generate-test-keys.mjs
+
+vars=$(mktemp)
+trap 'rm -f "$vars"' EXIT
+{
+  printf 'TEST_SECRET=%s\n' "$test_secret"
+  printf 'OPTIONS_FIXTURES=1\n'
+  printf "JWT_PRIVATE_KEY='%s'\n" "$(cat /tmp/jwt-private-key.txt)"
+  printf "JWKS='%s'\n" "$(cat /tmp/jwks.json)"
+} >"$vars"
+
+port_free() {
+  ! (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null
+}
+
+# Stable across runs so the URLs in .env.local keep working, and spread across
+# checkouts so two of them never want the same pair. Walks on if something else
+# already holds it, which is also what covers a path collision.
+SLOTS=300
+claim_ports() {
+  local seed offset i
+  seed=$(printf '%s' "$PWD" | shasum | cut -c1-4)
+  offset=$((0x$seed % SLOTS))
+  for i in $(seq 0 $((SLOTS - 1))); do
+    cloud_port=$((3210 + 2 * ((offset + i) % SLOTS)))
+    site_port=$((cloud_port + 1))
+    if port_free "$cloud_port" && port_free "$site_port"; then
+      return 0
+    fi
+  done
+  echo "No free port pair between 3210 and $((3210 + 2 * SLOTS - 1))." >&2
+  exit 1
+}
+
+# Creates the deployment, downloads the backend binary, pins the port pair and
+# writes the URLs to .env.local. Only `convex dev` can do this — `convex env`
+# needs a deployment that already exists. Later runs reuse the saved ports.
+if [ ! -f .convex/local/default/config.json ]; then
+  claim_ports
+  bunx convex dev --once --tail-logs disable \
+    --local-cloud-port "$cloud_port" --local-site-port "$site_port"
+fi
+
+bunx convex env set --force --from-file "$vars"
+
+# Push again with the switches in place: convex/http.ts reads TEST_SECRET at
+# module level, so /test/* only registers if the push came after it was set.
+bunx convex dev --once --tail-logs disable
+
+# The CLI owns CONVEX_DEPLOYMENT/VITE_CONVEX_URL/VITE_CONVEX_SITE_URL in this
+# file; TEST_SECRET is ours.
+if [ ! -f "$ENV_FILE" ] || ! grep -qE '^TEST_SECRET=' "$ENV_FILE"; then
+  printf '\nTEST_SECRET=%s\n' "$test_secret" >>"$ENV_FILE"
+fi
+
+echo "Local backend ready — $(read_env VITE_CONVEX_URL)"

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -13,6 +13,14 @@ cd "$(dirname "$0")/.."
 
 ENV_FILE=.env.local
 
+# The suite needs a Vite server of this checkout's own. On the shared :5173 a
+# second checkout would find the first one's server there and — Playwright
+# reuses an existing one locally — drive that instead: a browser on backend A
+# while the helpers seed backend B. Setting this turns the reuse off too.
+. scripts/ports.sh
+claim_ports 5173 1
+export E2E_WEB_PORT=$claimed_port
+
 if [ -f "$ENV_FILE" ] && ! grep -qE '^CONVEX_DEPLOYMENT=anonymous:' "$ENV_FILE"; then
   set -a
   . "./$ENV_FILE"
@@ -24,7 +32,7 @@ fi
 # (TEST_SECRET, OPTIONS_FIXTURES, auth keys) before the push below.
 scripts/backend-up.sh
 
-status_file=$(mktemp)
+status_file=$(mktemp "${TMPDIR:-/tmp}/woty-e2e.XXXXXX") # BSD mktemp ignores TMPDIR without a template
 trap 'rm -f "$status_file"' EXIT
 
 # `convex dev` owns the backend process, so the suite has to run as its child:

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Runs Playwright against whatever backend `.env.local` names. A deployment
+# somebody else configured — the cloud dev deployment — is used exactly as
+# `test:web` always used it. An anonymous one, or no .env.local at all, means
+# this checkout owns its backend: bring it up, push this branch to it, run the
+# suite as a child of `convex dev`, stop it again. Nothing outside this
+# worktree sees that push.
+#
+# Extra arguments go to `playwright test` (flags and paths, no spaces).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ENV_FILE=.env.local
+
+if [ -f "$ENV_FILE" ] && ! grep -qE '^CONVEX_DEPLOYMENT=anonymous:' "$ENV_FILE"; then
+  set -a
+  . "./$ENV_FILE"
+  set +a
+  exec bunx playwright test "$@"
+fi
+
+# Idempotent, and it re-applies the deployment switches the suite needs
+# (TEST_SECRET, OPTIONS_FIXTURES, auth keys) before the push below.
+scripts/backend-up.sh
+
+status_file=$(mktemp)
+trap 'rm -f "$status_file"' EXIT
+
+# `convex dev` owns the backend process, so the suite has to run as its child:
+# the deployment is only up for the length of the command it starts. That
+# command's exit status doesn't reach us — `convex dev` exits 0 whenever its own
+# push succeeded — so the suite reports its own, and an empty file means it
+# never got to run.
+bunx convex dev --once --tail-logs disable \
+  --start "bunx playwright test $*; echo \$? >$status_file"
+
+status=$(cat "$status_file")
+exit "${status:-1}"

--- a/scripts/generate-test-keys.mjs
+++ b/scripts/generate-test-keys.mjs
@@ -1,14 +1,21 @@
 // Mints an ephemeral RS256 keypair for hermetic CI runs, in the same format
 // @convex-dev/auth expects (PKCS8 with spaces for JWT_PRIVATE_KEY, JWKS JSON).
-// Writes /tmp/jwt-private-key.txt and /tmp/jwks.json.
+// Writes jwt-private-key.txt and jwks.json to the directory given as the first
+// argument, defaulting to /tmp. Anything that can run concurrently with another
+// checkout must pass a directory of its own: the two files are read back as a
+// pair, and a keypair from one run mixed with one from another authenticates
+// nothing.
 import { writeFileSync } from "node:fs";
+import { join } from "node:path";
 
 import { exportJWK, exportPKCS8, generateKeyPair } from "jose";
+
+const outDir = process.argv[2] ?? "/tmp";
 
 const { privateKey, publicKey } = await generateKeyPair("RS256", { extractable: true });
 const pkcs8 = (await exportPKCS8(privateKey)).trimEnd().replace(/\n/g, " ");
 const jwk = await exportJWK(publicKey);
 const jwks = JSON.stringify({ keys: [{ use: "sig", ...jwk }] });
 
-writeFileSync("/tmp/jwt-private-key.txt", pkcs8);
-writeFileSync("/tmp/jwks.json", jwks);
+writeFileSync(join(outDir, "jwt-private-key.txt"), pkcs8);
+writeFileSync(join(outDir, "jwks.json"), jwks);

--- a/scripts/ports.sh
+++ b/scripts/ports.sh
@@ -1,0 +1,34 @@
+# Port derivation shared by backend-up.sh and e2e.sh. Sourced, not run.
+#
+# A port comes from the checkout's path, so each checkout keeps the same one
+# across runs and two checkouts never want the same one. The scan walks on when
+# something else already holds a block, which is also what covers the case of
+# two paths hashing to the same offset.
+
+PORT_SLOTS=300
+
+port_free() {
+  ! (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null
+}
+
+# claim_ports <base> <width>: sets $claimed_port to the start of the first free
+# block of <width> consecutive ports, scanning blocks from this checkout's
+# offset.
+claim_ports() {
+  local base=$1 width=$2 seed offset i port p taken
+  seed=$(printf '%s' "$PWD" | shasum | cut -c1-4)
+  offset=$((0x$seed % PORT_SLOTS))
+  for i in $(seq 0 $((PORT_SLOTS - 1))); do
+    port=$((base + width * ((offset + i) % PORT_SLOTS)))
+    taken=
+    for ((p = port; p < port + width; p++)); do
+      port_free "$p" || taken=1
+    done
+    if [ -z "$taken" ]; then
+      claimed_port=$port
+      return 0
+    fi
+  done
+  echo "No free block of $width ports from $base to $((base + width * PORT_SLOTS - 1))." >&2
+  exit 1
+}


### PR DESCRIPTION
## Summary

Every local push went to the one shared cloud dev deployment, so a branch could put every other client on its API and a schema change could be refused by rows another branch left behind. Each checkout can now bring up its own throwaway Convex backend, and the whole pre-PR bar is one command, `bun run gate`. Ryan's cloud dev deployment is untouched: `convex:dev` and `test:web` against a cloud `.env.local` behave exactly as before. The pipeline's gate is the first consumer of the local path.

Closes #154

## Changes

- `scripts/backend-up.sh` (`backend:up` / `backend:reset`): an anonymous local deployment (`CONVEX_AGENT_MODE=anonymous`, documented in `convex init --help`, marked beta by the CLI), CLI-managed binary, state in `.convex/` (gitignored). Port pair derived from the checkout's path so two worktrees never collide. Sets `TEST_SECRET`, `OPTIONS_FIXTURES`, and a fresh RS256 keypair on it. Refuses to run, and `--reset` refuses to delete, when `.env.local` names a cloud deployment through either `CONVEX_DEPLOYMENT` or `VITE_CONVEX_URL`.
- `scripts/e2e.sh` is the new `test:web`. Cloud `.env.local` → sourced and used as before. Anonymous or no `.env.local` → brings up the local backend and runs Playwright as a child of `convex dev --once --start`, carrying Playwright's exit status out (`convex dev` exits 0 whenever its own push succeeded). Claims its own Vite port (`E2E_WEB_PORT`) so a second checkout never adopts the first one's server.
- `scripts/ports.sh`: shared port derivation, sourced by both scripts.
- `scripts/generate-test-keys.mjs`: takes an output directory instead of fixed `/tmp` paths, so concurrent checkouts cannot mix keypairs. CI passes `/tmp` explicitly (unchanged behaviour).
- `playwright.config.ts`: `baseURL` / `webServer` honour `E2E_WEB_PORT` with `--strictPort`; reuse of an existing server is off when the port is set. A bare `bunx playwright test` keeps `:5173` and reuse.
- `package.json`: `backend:up`, `backend:reset`, `gate`; `test:web` → `scripts/e2e.sh`; `convex:dev` unchanged.
- `CLAUDE.md`, `docs/local-dev.md`, `docs/contributing.md`: `bun run gate` replaces the four-check incantation; `local-dev.md` gains "Local backend (optional)".
- `.gitignore`: `.convex/`.

## Verification

Ran `bun run gate` in a clean worktree with no `.env.local` and no `.convex/`, outside the agent sandbox (which cannot bind ports): format, lint, types, 117 unit tests, then `scripts/e2e.sh` created the local deployment on a path-derived port pair, started Vite on `:5417`, and ran all 29 Playwright specs green in 50 s. Verified earlier in the run: a red spec exits `test:web` with 1; `backend:up` refuses a cloud `.env.local`; two checkouts can be up at once (this was the review's first finding and the fix is the second commit).

Not run: the four checks against a cloud `.env.local` after this change (the cloud path in `e2e.sh` is a pass-through of the old command, unchanged from what CI and the previous `test:web` did).

## Notes for reviewer

- `CLAUDE.md` and both `docs/*.md` change: `gate` becomes the named pre-PR command. `.claude/skills/implement-ticket/SKILL.md` deliberately still lists the four checks, because the implement agent's sandbox cannot bind ports and `gate` would always fail there.
- The pipeline's runner (`.pipeline/run.sh`, not in the repo) now runs `backend:up` in each worktree when the branch has the script, and falls back to the old behaviour otherwise. That change is live on the mini; this PR is what makes it do something.
- Three commits: implement, the review's three findings (Vite port collision, `/tmp` keypair race, `--reset` deleting a cloud `.env.local`), and one more found while verifying (stale `.convex/` state with a missing `.env.local` skipped deployment creation). Squash on merge.
- `convex/_generated` is rewritten by every local push (CLI drift); restored before each commit. #165 makes that stop.
- Start with `scripts/e2e.sh`: the cloud-vs-local branch at the top is the whole "Ryan's loop is unchanged" guarantee.