### PR TITLE
chore(pipeline): declare how this repo is set up, checked, gated and granted

### DIFF
--- a/.pipeline.json
+++ b/.pipeline.json
@@ -1,0 +1,7 @@
+{
+  "setup": "bun install --frozen-lockfile && bunx playwright install chromium",
+  "checks": "bun run check:format && bun run check:lint && bun run check:types && bun test",
+  "gate": "bun run check:format && bun run check:lint && bun run check:types && bun test && bun run test:web",
+  "env_allow": "CONVEX_DEPLOYMENT|VITE_CONVEX_URL|CONVEX_SITE_URL|TEST_SECRET",
+  "tools": "Bash(bun:*),Bash(bunx:*)"
+}


### PR DESCRIPTION
## Summary

The agent pipeline hardcoded five things that are this repo's business, not a runner's: `bun install --frozen-lockfile` as worktree setup, the Playwright browser install, the four checks, the full gate, and `Bash(bun:*),Bash(bunx:*)` in the tool grant handed to agents. A Go repo would have had to edit the runner to get `Bash(go:*)`.

They move here, tracked and reviewed like anything else the repo owns. The runner now knows only a checkout path — it takes this repo's identity from the git remote and its board from the linked project, and reads the rest from this file. It names no build tool anywhere; it knows `git`, `gh`, `jq` and `claude`, and the repo supplies the rest.

Follows #184.

## Changes

- `.pipeline.json` at the repo root:
  - `setup` — `bun install --frozen-lockfile && bunx playwright install chromium`. Run once in a fresh worktree. The browser install used to be padding on the front of the gate command.
  - `checks` — the four checks, no e2e. What an agent runs before committing; an agent sandbox usually cannot bind `:5173`.
  - `gate` — the four checks plus `test:web`. What must pass before a PR opens.
  - `env_allow` — `CONVEX_DEPLOYMENT|VITE_CONVEX_URL|CONVEX_SITE_URL|TEST_SECRET`.
  - `tools` — `Bash(bun:*),Bash(bunx:*)`, appended to the write stages' `--allowedTools`.

## Verification

- `bun run check:format`, `bun run check:lint`, `bun run check:types`, `bun test` — pass.
- Read end to end by the runner: a tick resolves this checkout, derives `30somethinggames/what-of-the-year` from the remote and project 3 from the linked project, reads all five fields, and reports `nothing ready`. Run by hand before this PR.
- Not verified: `setup` and `gate` have not been executed by the runner since they moved here — the queue has been empty. `gate` is character-for-character what the runner ran before, minus the browser install now in `setup`. The first real ticket is the proof.
- e2e not run locally; this PR adds one config file and touches no application code.

## Notes for reviewer

- **`env_allow` is the line with a security consequence.** An agent worktree gets a filtered copy of `.env.local`, and this is the filter. It is an allowlist, so a credential added to `.env.local` later reaches no agent until someone names it here — which then shows up as a reviewable line saying so. `CONVEX_DEPLOY_KEY` is deliberately absent; it will need adding when #154's preview flow moves into the gate, and that is a change worth noticing.
- `checks` and `gate` are deliberately different, as they always were: agents run the cheap set, the pipeline runs everything.
- `tools` widens what agents may execute in a worktree. Today it is bun only. Anything added here is a capability grant, not a convenience.
- No dependency added, no generated file touched, no application code touched.
