### PR TITLE
chore(rules): branches are named for the ticket they close

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -13,8 +13,8 @@ jobs:
           TITLE: ${{ github.event.pull_request.title }}
         run: |
           # type(scope): summary — type ∈ feat|fix|chore|ci; scope is the area touched
-          # ([a-z0-9-], e.g. convex, lobby, deps), never an issue number or seery/agent prefix.
+          # ([a-z0-9-], e.g. convex, lobby, deps), never an issue number or a branch prefix.
           if ! printf '%s\n' "$TITLE" | grep -Eq '^(feat|fix|chore|ci)\([a-z][a-z0-9-]*\): \S'; then
-            echo "::error::PR title must be 'type(scope): summary' (type feat|fix|chore|ci; scope = area touched, e.g. convex, lobby, deps — not an issue number or seery/agent prefix). Got: $TITLE"
+            echo "::error::PR title must be 'type(scope): summary' (type feat|fix|chore|ci; scope = area touched, e.g. convex, lobby, deps — not an issue number or a branch prefix). Got: $TITLE"
             exit 1
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,6 @@ Docs, read when relevant:
 ## Git
 
 - `type(scope): summary`, type ∈ `feat|fix|chore|ci`, scope = area touched. PR titles too.
-- Branches: `seery/<topic>` for human work, `agent/<issue#>-<slug>` for agent work.
+- Branches: `<issue#>/<slug>`. Commits and PR titles carry the type, not the branch.
 - Fill every section of the PR template. `Closes #<issue>` goes in the PR **description**, one line per ticket.
 - Never add a `Claude-Session` trailer to commits or a session link to PR bodies.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -5,16 +5,19 @@ versions of these rules; this is the reasoning behind them.
 
 ## Branches
 
-- Human work: `seery/<topic>`.
-- Agent work: `agent/<issue#>-<slug>`. These branches are opened by an agent
-  pipeline that polls the project board and runs on a machine outside this
-  repo; it implements one Ready ticket per run and opens a PR. It never
-  merges, and every PR it opens is read by a person like any other.
+`<issue#>/<slug>`, one branch per ticket:
 
-Provenance lives in the branch name and the `Co-Authored-By` trailer, never in
-the commit scope. That keeps `git log` readable by area and still answers "who
-wrote this" from the PR. Never add a `Claude-Session` trailer to commits or a
-session link to PR bodies.
+    187/e2e-provisions-its-own-preview
+    189/guest-sees-wrong-toast
+    190/rename-scripts
+
+The number is the ticket the branch closes, so a branch points at the reason it
+exists and every branch groups under its issue. Nothing else belongs in the
+name: not who wrote it, not what wrote it, not what kind of change it is — the
+commits say that, in Conventional Commits form, and so does the PR title.
+Provenance lives in the `Co-Authored-By` trailer, and every PR is read and
+merged by a person regardless. Never add a `Claude-Session` trailer to commits
+or a session link to PR bodies.
 
 ## Commits and PR titles
 


### PR DESCRIPTION
## Summary

`seery/<topic>` put one person's name in the convention, and `agent/<issue#>-<slug>` put the author in the branch name. Neither describes the change, and the first stops being true the moment anyone else works in this repo.

Branches are `<issue#>/<slug>`:

```
187/e2e-provisions-its-own-preview
189/guest-sees-wrong-toast
190/rename-scripts
```

The number is the ticket the branch closes, so a branch points at the reason it exists and branches group under their issue. Nothing else belongs in the name — not who wrote it, not what wrote it, not the kind of change. Conventional Commits already carries the type, in the commits and in the PR title.

## Changes

- `docs/contributing.md`: the convention, with examples. Also drops the claim that provenance lives in the branch name — it lives in the `Co-Authored-By` trailer, and saying otherwise is what made the prefixes look load-bearing.
- `CLAUDE.md`: one line, matching.
- `.github/workflows/pr-title.yml`: its error message cited the old prefixes as examples of what not to put in a PR title; it now says "a branch prefix". What it accepts and rejects is unchanged.

## Verification

- `bun run check` passes.
- No workflow, ruleset or script keys off the old prefixes — checked with `git grep` across the repo, and the branch-protection ruleset targets `main` only.
- Nothing here changes behaviour, so there is nothing to run; CI is the check.

## Notes for reviewer

- **`.github/**` change**, disclosed per `CLAUDE.md`: message text only in `pr-title.yml`.
- Existing branches are unaffected; this is the rule for new ones. A number of stale local `agent/*` branches from earlier work can be pruned whenever.
- This needed a matching change outside this repo, already made. The thing that opens branches for tickets built `agent/<issue>-<slug>` directly; it builds `<issue>/<slug>` now. That is strictly simpler than what it did before — both parts of the name are known when the branch is created, so there is nothing to defer or rename.
