### PR TITLE
ci(rules): accept the full Conventional Commits type set

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -12,9 +12,10 @@ jobs:
         env:
           TITLE: ${{ github.event.pull_request.title }}
         run: |
-          # type(scope): summary — type ∈ feat|fix|chore|ci; scope is the area touched
-          # ([a-z0-9-], e.g. convex, lobby, deps), never an issue number or a branch prefix.
-          if ! printf '%s\n' "$TITLE" | grep -Eq '^(feat|fix|chore|ci)\([a-z][a-z0-9-]*\): \S'; then
-            echo "::error::PR title must be 'type(scope): summary' (type feat|fix|chore|ci; scope = area touched, e.g. convex, lobby, deps — not an issue number or a branch prefix). Got: $TITLE"
+          # type(scope): summary — the Conventional Commits types; scope is the area
+          # touched ([a-z0-9-], e.g. convex, lobby, deps), never an issue number or a
+          # branch prefix. Only feat and fix affect a release; see docs/release.md.
+          if ! printf '%s\n' "$TITLE" | grep -Eq '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)\([a-z][a-z0-9-]*\): \S'; then
+            echo "::error::PR title must be 'type(scope): summary'. type ∈ build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test; scope = area touched, e.g. convex, lobby, deps — not an issue number or a branch prefix. Got: $TITLE"
             exit 1
           fi

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -12,10 +12,11 @@ jobs:
         env:
           TITLE: ${{ github.event.pull_request.title }}
         run: |
-          # type(scope): summary — the Conventional Commits types; scope is the area
+          # type(scope): summary — the Conventional Commits types. Scope is the area
           # touched ([a-z0-9-], e.g. convex, lobby, deps), never an issue number or a
           # branch prefix. Only feat and fix affect a release; see docs/release.md.
-          if ! printf '%s\n' "$TITLE" | grep -Eq '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)\([a-z][a-z0-9-]*\): \S'; then
-            echo "::error::PR title must be 'type(scope): summary'. type ∈ build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test; scope = area touched, e.g. convex, lobby, deps — not an issue number or a branch prefix. Got: $TITLE"
+          TYPES='build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test'
+          if ! printf '%s\n' "$TITLE" | grep -Eq "^($TYPES)\([a-z][a-z0-9-]*\): \S"; then
+            echo "::error::PR title must be 'type(scope): summary'. type is one of ${TYPES//|/, }; scope is the area touched, e.g. convex, lobby, deps — not an issue number or a branch prefix. Got: $TITLE"
             exit 1
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Docs, read when relevant:
 
 ## Git
 
-- `type(scope): summary`, type ∈ `feat|fix|chore|ci`, scope = area touched. PR titles too.
+- `type(scope): summary`, type = any Conventional Commits type, scope = area touched. PR titles too.
 - Branches: `<issue#>/<slug>`. Commits and PR titles carry the type, not the branch.
 - Fill every section of the PR template. `Closes #<issue>` goes in the PR **description**, one line per ticket.
 - Never add a `Claude-Session` trailer to commits or a session link to PR bodies.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -21,12 +21,31 @@ or a session link to PR bodies.
 
 ## Commits and PR titles
 
-Conventional Commits: `type(scope): summary`, type is one of `feat`, `fix`,
-`chore`, `ci`. The scope is the area touched (`convex`, `lobby`, `round`,
-`session`, `ci`, `deps`, `rules`), never the author or the issue number. PR
-titles use the same format; `pr-title.yml` rejects anything else, and the
-release tooling reads the type to decide the version bump and changelog
-section (see `release.md`).
+Conventional Commits: `type(scope): summary`. The scope is the area touched
+(`convex`, `lobby`, `round`, `session`, `ci`, `deps`, `rules`), never the author
+or the issue number, and it is required. PR titles use the same format;
+`pr-title.yml` rejects anything else.
+
+The types are the Conventional Commits set. Pick the one that describes the
+change, not the one that sounds safest:
+
+| | |
+| --- | --- |
+| `feat` | new behaviour someone can use |
+| `fix` | a defect in behaviour that already shipped |
+| `perf` | same behaviour, measurably faster or smaller |
+| `refactor` | same behaviour, different shape |
+| `docs` | documentation and comments only |
+| `test` | tests only |
+| `style` | formatting only, no code meaning changed |
+| `build` | dependencies, bundling, the toolchain |
+| `ci` | workflows and anything that runs in CI |
+| `chore` | housekeeping that fits nothing above |
+| `revert` | undoing an earlier commit |
+
+Only `feat` and `fix` change a version, and only the types listed in
+`changelog-sections` appear in the changelog — everything else rides along
+silently. So the type is for the reader, not for the release; see `release.md`.
 
 ## Before asking for review
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -19,7 +19,7 @@ registry; the package stays private.
 | `include-component-in-tag` | `false` | plain `v0.1.0` tags. The `node` strategy derives the component from the package name, and the schema default is `true`, so dropping this line would produce `what-of-the-year-v0.1.0` |
 | `pull-request-title-pattern` | `chore(release): v${version}` | matches the `type(scope)` PR title convention |
 | `bootstrap-sha` | main's tip at adoption | there is no `v0.0.1` tag to anchor on; without it the first release PR replays ~150 commits of history. The first changelog entry starts at adoption and earlier `feat`/`fix` commits are not backfilled |
-| `changelog-sections` | `feat`, `fix`, `ci` | `chore` commits are hidden from the changelog on purpose; release-please still reads them, they just don't get a section |
+| `changelog-sections` | `feat`, `fix`, `ci` | every other type is hidden from the changelog on purpose; release-please still reads them, they just don't get a section. Which types deserve a heading is independent of which types a PR title may use |
 
 Only `feat` and `fix` commits bump the version (`fix` → patch, `feat` → minor,
 `!` / `BREAKING CHANGE` → major). `ci` and `chore` commits ride along in the


### PR DESCRIPTION
## Summary

`pr-title.yml` accepted four types — `feat`, `fix`, `chore`, `ci` — so a documentation-only PR had to call itself a chore, and so did a refactor, a test-only change and a performance fix. The type is the first thing a reader sees, and it was being spent on nothing.

The restriction was not protecting the release. `release-please` bumps on `feat` and `fix` alone, and `changelog-sections` decides what reaches the changelog; any type missing from that list rides along hidden, which is already how `chore` behaves.

Closes #195

## Changes

- `.github/workflows/pr-title.yml`: accepts `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`. The error message lists them.
- `docs/contributing.md`: a table of what each type is for. Eleven bare words invite picking the safest rather than the accurate one.
- `CLAUDE.md`: one line, matching.
- `docs/release.md`: says plainly that only `feat` and `fix` change a version and only the listed sections reach the changelog, so the type is for the reader rather than the release.
- `release-please-config.json` is untouched. Which types deserve a changelog heading is a separate question from which types a PR title may use.

## Verification

- The regex was run against real titles: `docs(e2e): …`, `refactor(convex): …`, `perf(round): …` and `chore(release): v0.0.3` accepted; `nonsense(scope): …`, `docs: no scope` and `feat(Convex): …` rejected.
- `bun run check` passes.
- This PR's own title is `ci(rules): …`, so the check runs against the unchanged path; the widened path is proven by the table above rather than by this run.

## Notes for reviewer

- **`.github/**` change**, disclosed per `CLAUDE.md`: the accepted set widens. Nothing that was rejected before is accepted now except the added types, and nothing previously accepted is rejected.
- Scope stays **required** and lowercase. Conventional Commits allows a bare `type: summary`; this repo does not. Worth deciding separately — `ci: retry flaky job` is a natural title that this still rejects.
- No dependency added, no application code touched.
