### PR TITLE
test(game): stop the forfeit spec racing its own setup

### DIFF
--- a/playwright/game/non-host.e2e.ts
+++ b/playwright/game/non-host.e2e.ts
@@ -145,6 +145,12 @@ test("non-host: host leaving game shows toast and redirects to home", async ({ b
   await expect(guestPage.getByTestId("setup-submit")).toBeEnabled();
   await guestPage.getByTestId("setup-submit").click();
 
+  // Wait for the join to reach the host before starting. Joins close when the
+  // session leaves the lobby, so starting first can land the guest's join on an
+  // active session, which is refused — the guest never joins and sees "Session
+  // is closed" instead of anything this test is about.
+  await expect(hostPage.getByText("Guest")).toBeVisible();
+
   await hostPage.getByTestId("lobby-start").click();
   await expect(guestPage.getByText("Round 10")).toBeVisible();
 


### PR DESCRIPTION
## Summary

`non-host: host leaving game shows toast and redirects to home` failed with the guest seeing `"Session is closed"` where the spec expected `"The host forfeited the game."` It had been reported as flaky, because `retries: 1` locally turned it green; with retries off it failed on both the attempt and the retry.

It was racing its own setup. The spec clicked the guest's **Join** and then immediately clicked the host's **Start**, with nothing synchronising two independent browser contexts. When Start won, `joinSession` landed on a session that had already left the lobby, was refused with `SESSION_CLOSED`, and left that toast on the guest's screen. The guest was never in the game, so the assertion about the forfeit toast was asserting against a state the test had prevented from happening.

Closes #189

## Changes

- `playwright/game/non-host.e2e.ts`: wait for the guest to appear in the host's lobby before the host starts, which is what the sibling spec three tests above already does. Plus a comment on why the ordering matters, so it does not get deleted as a redundant assertion.

## Verification

- Before: failed on the first attempt **and** the retry, in a pipeline gate dry-run.
- After: `bun run test:e2e -- playwright/game/non-host.e2e.ts --retries 0 --repeat-each 5` → **15 passed (47.4s)**, three specs, five repeats each, retries off.
- `bun run check` passes.
- Not re-run: the full suite. CI does that.

## Notes for reviewer

- **No assertion was changed, loosened or removed**, and no retry or timeout was added. The spec's expectations were right; its setup was not.
- **Not a product bug.** Joins close when a session leaves the lobby — intended, and `join-closed.e2e.ts` covers it directly. `convex/players.ts:32` refusing a join on an active session is correct behaviour that this test was accidentally triggering.
- Worth knowing why it surfaced now: it was found by a pipeline gate dry-run, where it blocked the gate outright. Any ticket run would have reached the gate and gone Blocked on it after a full implement/review/fix cycle.
- No dependency added, no application code touched.
