### PR TITLE
chore(rules): put the ticket link first in a PR description

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,8 @@
+Closes #
+
 ## Summary
 
 What this PR does and why.
-
-Closes #
 
 ## Changes
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -85,10 +85,15 @@ tag can be moved to point at different code.
 
 ## Closing tickets
 
-Every PR that resolves a ticket carries `Closes #<issue>` in its
-**description**, one line per ticket. Commit-message keywords are not enough:
-`main` accepts only squash and rebase merges, and after either the body
-keyword is the reliable auto-close path.
+Every PR that resolves a ticket opens with `Closes #<issue>`, first line of the
+description, one line per ticket. It goes first because it is the link back to
+why the change exists, which is the first thing a reader wants.
+
+It has to be the **description** rather than a commit message. `main` squashes
+with the commit messages as the body, so the description never becomes the
+commit — what closes the ticket is GitHub linking it from the PR itself when the
+PR merges. That works wherever the keyword sits in the body; first is a choice,
+not a requirement.
 
 ## Merging
 


### PR DESCRIPTION
Closes #200

## Summary

`Closes #<issue>` sat at the bottom of a PR's Summary section, below a paragraph of prose, when it is the most useful line in the description — the link back to why the change exists.

Nothing required it there. `main` squashes with `squash_merge_commit_message: COMMIT_MESSAGES`, so the description never becomes the commit message; what closes the ticket is GitHub linking it from the PR itself when the PR merges, and that works wherever the keyword appears in the body.

This description is the first PR written to the new shape.

## Changes

- `.github/pull_request_template.md`: `Closes #` is the first line, above `## Summary`.
- `docs/contributing.md`: says the line goes first and why the description rather than a commit is what closes the ticket. The old wording — "commit-message keywords are not enough" — was true without explaining what *was* enough.

## Verification

- `bun run check` passes.
- The closing mechanism is unchanged, so merging this PR closing #200 is itself the test.
- Not verified by a run: nothing here executes.

## Notes for reviewer

- **`.github/**` change**, disclosed per `CLAUDE.md`: the PR template's section order.
- This needed a matching change outside this repo, already made: the PR-writer prompt's template now opens with the line, and the runner's fallback — which adds `Closes` when the writer omits it — prepends instead of appending. Verified the prepend produces the right shape.
- While in that file: the same prompt still told agents commit types were `feat|fix|chore|ci`, which stopped being true at #196. Fixed there.
- No dependency added, no application code touched.
