### PR TITLE
chore(convex): seed a session at a given phase, server-side

### DIFF
--- a/convex/__tests__/harness.setup.ts
+++ b/convex/__tests__/harness.setup.ts
@@ -2,9 +2,10 @@ import { Glob } from "bun";
 
 import { convexTest } from "convex-test";
 
-import type { Id } from "../_generated/dataModel";
-import { MAX_PLAYERS, MAX_ROUNDS, SessionStatus } from "../constants";
+import { MAX_ROUNDS } from "../constants";
 import schema from "../schema";
+import type { Phase, SeededGame } from "../test/phases";
+import { seedSession } from "../test/phases";
 
 // `convex-test` normally discovers modules via Vite's `import.meta.glob`, which
 // Bun does not implement — build the equivalent `path -> loader` map by hand.
@@ -15,21 +16,38 @@ const RATE_LIMITER_ROOT = new URL(
   import.meta.url,
 ).pathname;
 
-function moduleMap(root: string) {
+function moduleMap(root: string, httpSuffix = "") {
   const modules: Record<string, () => Promise<unknown>> = {};
 
   for (const path of new Glob("**/*.{ts,js}").scanSync({ cwd: root })) {
     if (path.endsWith(".d.ts") || path.includes(".test.") || path.startsWith("__tests__/"))
       continue;
-    modules[`./${path}`] = () => import(root + path);
+    const specifier = root + path + (path === "http.ts" ? httpSuffix : "");
+    modules[`./${path}`] = () => import(specifier);
   }
 
   return modules;
 }
 
+/**
+ * `convex/http.ts` decides at module evaluation which `/test/*` routes exist,
+ * so a test that changes `TEST_SECRET` or `IS_PROD` has to get past bun's
+ * module cache. A distinct specifier is the only way; everything http.ts
+ * imports stays shared.
+ */
+let httpGeneration = 0;
+
+interface SetupOptions {
+  /** Evaluate `convex/http.ts` again, against the environment set right now. */
+  freshHttp?: boolean;
+}
+
 /** A `convex-test` instance with the rate limiter component registered. */
-export async function setupTest() {
-  const t = convexTest(schema, moduleMap(CONVEX_ROOT));
+export async function setupTest({ freshHttp = false }: SetupOptions = {}) {
+  const t = convexTest(
+    schema,
+    moduleMap(CONVEX_ROOT, freshHttp ? `?http=${++httpGeneration}` : ""),
+  );
   const rateLimiterSchema = (await import(`${RATE_LIMITER_ROOT}schema.ts`)).default;
 
   t.registerComponent("rateLimiter", rateLimiterSchema, moduleMap(RATE_LIMITER_ROOT));
@@ -43,61 +61,28 @@ export const OUTSIDER_UID = "outsider-uid";
 
 type TestConvex = Awaited<ReturnType<typeof setupTest>>;
 
-export type SeededGame = {
-  sessionId: Id<"sessions">;
-  roundIds: Id<"rounds">[];
-};
+export type { SeededGame };
+
+/** The two players every harness seed carries: `HOST_UID` hosts, `MEMBER_UID` joins. */
+const PLAYERS = [
+  { name: "Host", avatar: "🐙", uid: HOST_UID },
+  { name: "Member", avatar: "🦊", uid: MEMBER_UID },
+];
+
+/**
+ * The phases below go through the same `seedSession` the `/test/seed-game`
+ * route uses, so a unit test and an e2e spec are looking at the same rows.
+ */
+function seedPhase(t: TestConvex, phase: Phase) {
+  return t.run((ctx) => seedSession(ctx, { phase, players: PLAYERS }));
+}
 
 /**
  * An ACTIVE session with a host, one other member, and `MAX_ROUNDS` rounds
  * where the highest-numbered round is `open` (matching `startSession`).
  */
 export async function seedActiveGame(t: TestConvex): Promise<SeededGame> {
-  return await t.run(async (ctx) => {
-    const sessionId = await ctx.db.insert("sessions", {
-      topic: "games",
-      year: 2025,
-      maxRounds: MAX_ROUNDS,
-      maxPlayers: MAX_PLAYERS,
-      playerCount: 2,
-      activeRoundNumber: MAX_ROUNDS,
-      status: SessionStatus.ACTIVE,
-    });
-
-    await ctx.db.insert("players", {
-      sessionId,
-      uid: HOST_UID,
-      name: "Host",
-      avatar: "🐙",
-      isHost: true,
-    });
-    await ctx.db.insert("players", {
-      sessionId,
-      uid: MEMBER_UID,
-      name: "Member",
-      avatar: "🦊",
-      isHost: false,
-    });
-
-    const roundIds: Id<"rounds">[] = [];
-
-    for (let number = 1; number <= MAX_ROUNDS; number++) {
-      const isActive = number === MAX_ROUNDS;
-      roundIds.push(
-        await ctx.db.insert("rounds", {
-          sessionId,
-          number,
-          state: isActive ? "open" : "pending",
-          weight: MAX_ROUNDS + 1 - number,
-          selectionsComplete: 0,
-          startedAt: isActive ? Date.now() : null,
-          closedAt: null,
-        }),
-      );
-    }
-
-    return { sessionId, roundIds };
-  });
+  return await seedPhase(t, `round:${MAX_ROUNDS}`);
 }
 
 /**
@@ -105,17 +90,7 @@ export async function seedActiveGame(t: TestConvex): Promise<SeededGame> {
  * rounds (matching `createSession`).
  */
 export async function seedLobbyGame(t: TestConvex): Promise<SeededGame> {
-  const game = await seedActiveGame(t);
-
-  await t.run(async (ctx) => {
-    await ctx.db.patch(game.sessionId, {
-      status: SessionStatus.LOBBY,
-      activeRoundNumber: 1,
-    });
-    await ctx.db.patch(game.roundIds[MAX_ROUNDS - 1], { state: "pending", startedAt: null });
-  });
-
-  return game;
+  return await seedPhase(t, "lobby");
 }
 
 /**
@@ -124,21 +99,7 @@ export async function seedLobbyGame(t: TestConvex): Promise<SeededGame> {
  * after round 2).
  */
 export async function seedFinalRound(t: TestConvex): Promise<SeededGame> {
-  const game = await seedActiveGame(t);
-
-  await t.run(async (ctx) => {
-    await ctx.db.patch(game.sessionId, { activeRoundNumber: 1 });
-    for (const [index, roundId] of game.roundIds.entries()) {
-      const isFinal = index === 0;
-      await ctx.db.patch(roundId, {
-        state: isFinal ? "open" : "closed",
-        startedAt: Date.now(),
-        closedAt: isFinal ? null : Date.now(),
-      });
-    }
-  });
-
-  return game;
+  return await seedPhase(t, "round:1");
 }
 
 /**
@@ -146,14 +107,7 @@ export async function seedFinalRound(t: TestConvex): Promise<SeededGame> {
  * `completeReveal` leaves after round 1).
  */
 export async function seedCompleteGame(t: TestConvex): Promise<SeededGame> {
-  const game = await seedFinalRound(t);
-
-  await t.run(async (ctx) => {
-    await ctx.db.patch(game.sessionId, { status: SessionStatus.COMPLETE });
-    await ctx.db.patch(game.roundIds[0], { state: "closed", closedAt: Date.now() });
-  });
-
-  return game;
+  return await seedPhase(t, "ended");
 }
 
 export const OPTION = {

--- a/convex/__tests__/test-routes.test.ts
+++ b/convex/__tests__/test-routes.test.ts
@@ -1,0 +1,235 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+
+import type { Doc, Id } from "../_generated/dataModel";
+import { MAX_ROUNDS, SessionStatus } from "../constants";
+import { setupTest } from "./harness.setup";
+
+const SECRET = "secret-of-exactly-this-length-ok";
+const WRONG = "wrong-of-exactly-this-length-abc";
+
+const CREATE = "/test/create-session";
+const SEED = "/test/seed-game";
+
+type TestConvex = Awaited<ReturnType<typeof setupTest>>;
+
+const realSecret = process.env.TEST_SECRET;
+const realIsProd = process.env.IS_PROD;
+
+beforeAll(() => {
+  process.env.TEST_SECRET = SECRET;
+  delete process.env.IS_PROD;
+});
+
+afterAll(() => {
+  if (realSecret === undefined) delete process.env.TEST_SECRET;
+  else process.env.TEST_SECRET = realSecret;
+  if (realIsProd === undefined) delete process.env.IS_PROD;
+  else process.env.IS_PROD = realIsProd;
+});
+
+/** `freshHttp` so the routes are registered against the secret set just above. */
+function post(t: TestConvex, path: string, body: unknown, secret: string | null = SECRET) {
+  return t.fetch(path, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(secret === null ? {} : { "x-test-secret": secret }),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+async function readGame(t: TestConvex, sessionId: Id<"sessions">) {
+  return await t.run(async (ctx) => ({
+    session: await ctx.db.get(sessionId),
+    players: await ctx.db
+      .query("players")
+      .withIndex("by_session_uid", (q) => q.eq("sessionId", sessionId))
+      .collect(),
+    rounds: (
+      await ctx.db
+        .query("rounds")
+        .withIndex("by_session", (q) => q.eq("sessionId", sessionId))
+        .collect()
+    ).sort((a, b) => a.number - b.number),
+    selections: await ctx.db
+      .query("selections")
+      .withIndex("by_session", (q) => q.eq("sessionId", sessionId))
+      .collect(),
+  }));
+}
+
+/** Round states low number first, so a phase reads as a picture of the game. */
+function states(rounds: Doc<"rounds">[]) {
+  return rounds.map((round) => round.state);
+}
+
+describe("POST /test/create-session", () => {
+  it("rejects a request with no secret", async () => {
+    const t = await setupTest({ freshHttp: true });
+
+    const response = await post(t, CREATE, { name: "Host" }, null);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects a request with the wrong secret", async () => {
+    const t = await setupTest({ freshHttp: true });
+
+    const response = await post(t, CREATE, { name: "Host" }, WRONG);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("creates a lobby session hosted by the named player", async () => {
+    const t = await setupTest({ freshHttp: true });
+
+    const response = await post(t, CREATE, { name: "Ryan", topic: "movies", year: 2024 });
+
+    expect(response.status).toBe(200);
+    const { sessionId, hostUid } = (await response.json()) as {
+      sessionId: Id<"sessions">;
+      hostUid: string;
+    };
+    expect(hostUid).toMatch(/^test-/);
+
+    const { session, players, rounds } = await readGame(t, sessionId);
+
+    expect(session).toMatchObject({
+      topic: "movies",
+      year: 2024,
+      status: SessionStatus.LOBBY,
+      playerCount: 1,
+      activeRoundNumber: 1,
+    });
+    expect(players).toHaveLength(1);
+    expect(players[0]).toMatchObject({ uid: hostUid, name: "Ryan", isHost: true });
+    expect(rounds).toHaveLength(MAX_ROUNDS);
+    expect(states(rounds).every((state) => state === "pending")).toBe(true);
+  });
+
+  it("hosts the session as the uid it is given", async () => {
+    const t = await setupTest({ freshHttp: true });
+
+    const response = await post(t, CREATE, { name: "Ryan", hostUid: "browser-uid" });
+
+    expect((await response.json()).hostUid).toBe("browser-uid");
+  });
+});
+
+describe("POST /test/seed-game", () => {
+  const players = [{ name: "Host" }, { name: "Guest" }];
+
+  it("rejects a request with no secret", async () => {
+    const t = await setupTest({ freshHttp: true });
+
+    const response = await post(t, SEED, { phase: "lobby", players }, null);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("opens the requested round and closes the ones already played", async () => {
+    const t = await setupTest({ freshHttp: true });
+
+    const response = await post(t, SEED, { phase: "round:8", players });
+
+    expect(response.status).toBe(200);
+    const { sessionId, roundIds, players: seeded } = await response.json();
+
+    expect(roundIds).toHaveLength(MAX_ROUNDS);
+    expect(seeded.map((player: { isHost: boolean }) => player.isHost)).toEqual([true, false]);
+
+    const { session, rounds } = await readGame(t, sessionId);
+
+    expect(session).toMatchObject({
+      status: SessionStatus.ACTIVE,
+      activeRoundNumber: 8,
+      playerCount: 2,
+    });
+    // Rounds count down: 1-7 are still to come, 8 is in play, 9 and 10 are done.
+    expect(states(rounds)).toEqual([
+      "pending",
+      "pending",
+      "pending",
+      "pending",
+      "pending",
+      "pending",
+      "pending",
+      "open",
+      "closed",
+      "closed",
+    ]);
+  });
+
+  it("puts a revealing round in play with the reveal job the timeout needs", async () => {
+    const t = await setupTest({ freshHttp: true });
+
+    const response = await post(t, SEED, {
+      phase: `revealing:${MAX_ROUNDS}`,
+      players,
+      selections: [
+        { uid: "a", roundNumber: MAX_ROUNDS, pickName: "Blue Prince" },
+        { uid: "b", roundNumber: MAX_ROUNDS, pickName: "Balatro" },
+      ],
+    });
+
+    const { sessionId } = await response.json();
+    const { session, rounds, selections } = await readGame(t, sessionId);
+    const revealing = rounds[MAX_ROUNDS - 1]!;
+
+    expect(session).toMatchObject({ status: SessionStatus.ACTIVE, activeRoundNumber: MAX_ROUNDS });
+    expect(revealing.state).toBe("revealing");
+    expect(revealing.selectionsComplete).toBe(2);
+    expect(revealing.closedAt).not.toBeNull();
+    expect(revealing.revealJobId).toBeDefined();
+    expect(revealing.revealEndsAt).toBeGreaterThan(Date.now());
+
+    expect(selections).toHaveLength(2);
+    expect(selections.map((selection) => selection.pick)).toContainEqual({
+      id: "blue-prince",
+      name: "Blue Prince",
+    });
+
+    // The seeded job is the real `completeReveal`, so the round closes itself
+    // on timeout exactly as one `advanceRound` opened would.
+    const job = await t.run(async (ctx) => await ctx.db.system.get(revealing.revealJobId!));
+    expect(job?.name).toBe("rounds:completeReveal");
+    expect(job?.state.kind).toBe("pending");
+    expect(job?.args[0]).toEqual({ sessionId, roundNumber: MAX_ROUNDS });
+  });
+
+  it("closes every round of an ended game and completes the session", async () => {
+    const t = await setupTest({ freshHttp: true });
+
+    const response = await post(t, SEED, { phase: "ended", players });
+
+    const { sessionId } = await response.json();
+    const { session, rounds } = await readGame(t, sessionId);
+
+    expect(session).toMatchObject({ status: SessionStatus.COMPLETE, activeRoundNumber: 1 });
+    expect(states(rounds).every((state) => state === "closed")).toBe(true);
+  });
+
+  it("refuses a phase it does not recognise", async () => {
+    const t = await setupTest({ freshHttp: true });
+
+    expect(post(t, SEED, { phase: "round:0", players })).rejects.toThrow(/out of range/);
+    expect(post(t, SEED, { phase: "halftime", players })).rejects.toThrow(/Unknown phase/);
+  });
+});
+
+describe("the /test/* routes on prod", () => {
+  it("registers none of them when IS_PROD is set", async () => {
+    process.env.IS_PROD = "1";
+    try {
+      const t = await setupTest({ freshHttp: true });
+
+      for (const path of [CREATE, SEED, "/test/add-player", "/test/make-selection"]) {
+        expect((await post(t, path, {})).status).toBe(404);
+      }
+      expect((await post(t, "/test/cleanup", {})).status).toBe(404);
+    } finally {
+      delete process.env.IS_PROD;
+    }
+  });
+});

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -24,6 +24,7 @@ import type * as selections from "../selections.js";
 import type * as sessions from "../sessions.js";
 import type * as test_fixtures from "../test/fixtures.js";
 import type * as test_http from "../test/http.js";
+import type * as test_phases from "../test/phases.js";
 import type * as test_seed from "../test/seed.js";
 import type * as tmdb from "../tmdb.js";
 import type * as utils_auth from "../utils/auth.js";
@@ -58,6 +59,7 @@ declare const fullApi: ApiFromModules<{
   sessions: typeof sessions;
   "test/fixtures": typeof test_fixtures;
   "test/http": typeof test_http;
+  "test/phases": typeof test_phases;
   "test/seed": typeof test_seed;
   tmdb: typeof tmdb;
   "utils/auth": typeof utils_auth;

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -2,13 +2,15 @@ import { httpRouter } from "convex/server";
 
 import { auth } from "./auth";
 import { upstreams } from "./health";
-import { addPlayer, cleanup, makeSelection } from "./test/http";
+import { addPlayer, cleanup, createSession, makeSelection, seedGame } from "./test/http";
 import { testRoutesEnabled } from "./utils/env";
 
 const http = httpRouter();
 auth.addHttpRoutes(http);
 
 if (testRoutesEnabled()) {
+  http.route({ path: "/test/create-session", method: "POST", handler: createSession });
+  http.route({ path: "/test/seed-game", method: "POST", handler: seedGame });
   http.route({ path: "/test/add-player", method: "POST", handler: addPlayer });
   http.route({ path: "/test/make-selection", method: "POST", handler: makeSelection });
   http.route({ path: "/test/cleanup", method: "POST", handler: cleanup });

--- a/convex/rounds.ts
+++ b/convex/rounds.ts
@@ -8,7 +8,7 @@ import { SessionStatus } from "./constants";
 import { rateLimiter } from "./ratelimits";
 import { requireSessionMember } from "./utils/auth";
 import { apiError } from "./utils/errors";
-import { getRoundByNumber } from "./utils/rounds";
+import { getRoundByNumber, revealDurationMs } from "./utils/rounds";
 
 export const getRound = query({
   args: { sessionId: v.id("sessions"), number: v.number() },
@@ -80,10 +80,10 @@ export const advanceRound = mutation({
       return;
     }
 
-    const revealDurationMs = session.playerCount * 4_000 + 5_000;
-    const revealEndsAt = Date.now() + revealDurationMs;
+    const durationMs = revealDurationMs(session.playerCount);
+    const revealEndsAt = Date.now() + durationMs;
 
-    const jobId = await ctx.scheduler.runAfter(revealDurationMs, internal.rounds.completeReveal, {
+    const jobId = await ctx.scheduler.runAfter(durationMs, internal.rounds.completeReveal, {
       sessionId,
       roundNumber: currentRoundNumber,
     });

--- a/convex/selections.ts
+++ b/convex/selections.ts
@@ -8,7 +8,7 @@ import { rateLimiter } from "./ratelimits";
 import { requireSessionMember } from "./utils/auth";
 import { apiError } from "./utils/errors";
 import { buildPickArg } from "./utils/pick";
-import { getRoundByNumber, isRoundRevealed } from "./utils/rounds";
+import { getRoundByNumber, isRoundRevealed, revealDurationMs } from "./utils/rounds";
 
 export const getSelections = query({
   args: { sessionId: v.id("sessions"), number: v.number() },
@@ -113,10 +113,10 @@ export const saveSelection = mutation({
     const allComplete = selectionsComplete > 0 && selectionsComplete >= session.playerCount;
 
     if (allComplete) {
-      const revealDurationMs = session.playerCount * 4_000 + 5_000;
-      const revealEndsAt = Date.now() + revealDurationMs;
+      const durationMs = revealDurationMs(session.playerCount);
+      const revealEndsAt = Date.now() + durationMs;
 
-      const jobId = await ctx.scheduler.runAfter(revealDurationMs, internal.rounds.completeReveal, {
+      const jobId = await ctx.scheduler.runAfter(durationMs, internal.rounds.completeReveal, {
         sessionId,
         roundNumber,
       });

--- a/convex/test/http.ts
+++ b/convex/test/http.ts
@@ -1,4 +1,5 @@
 import { internal } from "../_generated/api";
+import type { ActionCtx } from "../_generated/server";
 import { httpAction } from "../_generated/server";
 import { timingSafeEqual } from "../utils/env";
 
@@ -11,29 +12,40 @@ function guardTest(request: Request) {
   return null;
 }
 
-export const addPlayer = httpAction(async (ctx, request) => {
-  const denied = guardTest(request);
-  if (denied) return denied;
+/**
+ * A `/test/*` route: the secret guard, the JSON body, and a JSON reply. The
+ * body reaches the mutation unvalidated on purpose — the mutation's own `args`
+ * validators are the check, and there is one of them rather than two.
+ */
+// oxlint-disable-next-line no-explicit-any -- the body is whatever the mutation validates.
+function testRoute(run: (ctx: ActionCtx, body: any) => Promise<unknown>) {
+  return httpAction(async (ctx, request) => {
+    const denied = guardTest(request);
+    if (denied) return denied;
 
-  const body = await request.json();
-  const result = await ctx.runMutation(internal.test.seed.addPlayer, body);
+    const result = (await run(ctx, await request.json())) ?? { ok: true };
 
-  return new Response(JSON.stringify(result), {
-    headers: { "Content-Type": "application/json" },
+    return new Response(JSON.stringify(result), {
+      headers: { "Content-Type": "application/json" },
+    });
   });
-});
+}
 
-export const makeSelection = httpAction(async (ctx, request) => {
-  const denied = guardTest(request);
-  if (denied) return denied;
+export const createSession = testRoute((ctx, body) =>
+  ctx.runMutation(internal.test.seed.createSession, body),
+);
 
-  const body = await request.json();
-  await ctx.runMutation(internal.test.seed.makeSelection, body);
+export const seedGame = testRoute((ctx, body) =>
+  ctx.runMutation(internal.test.seed.seedGame, body),
+);
 
-  return new Response(JSON.stringify({ ok: true }), {
-    headers: { "Content-Type": "application/json" },
-  });
-});
+export const addPlayer = testRoute((ctx, body) =>
+  ctx.runMutation(internal.test.seed.addPlayer, body),
+);
+
+export const makeSelection = testRoute((ctx, body) =>
+  ctx.runMutation(internal.test.seed.makeSelection, body),
+);
 
 export const cleanup = httpAction(async (ctx, request) => {
   const denied = guardTest(request);

--- a/convex/test/phases.ts
+++ b/convex/test/phases.ts
@@ -1,0 +1,194 @@
+/**
+ * One definition of what a phase looks like, shared by the `convex-test`
+ * harness (`convex/__tests__/harness.setup.ts`) and the `/test/seed-game`
+ * route, so a unit test and an e2e spec never disagree about what `round:7` or
+ * `ended` means.
+ *
+ * Test-only: plain `Error` throws are fine here (never reachable on prod).
+ */
+import { internal } from "../_generated/api";
+import type { Doc, Id } from "../_generated/dataModel";
+import type { MutationCtx } from "../_generated/server";
+import { MAX_PLAYERS, MAX_ROUNDS, SessionStatus, Topic } from "../constants";
+import { revealDurationMs } from "../utils/rounds";
+
+/** A uid for a player no browser will ever sign in as. */
+export function testUid() {
+  return `test-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+/** The id a pick carries when the seed invents one from a name. */
+export function pickId(name: string) {
+  return name.toLowerCase().replace(/\s+/g, "-");
+}
+
+/**
+ * `lobby`, `ended`, or a round number: `round:7` is round 7 open and waiting on
+ * picks, `revealing:7` is round 7 closed and showing them. Rounds count down,
+ * so a game starts at `round:10` and finishes at `round:1`.
+ */
+export type Phase = "lobby" | "ended" | `round:${number}` | `revealing:${number}`;
+
+type ParsedPhase =
+  | { kind: "lobby" }
+  | { kind: "ended" }
+  | { kind: "round" | "revealing"; number: number };
+
+export function parsePhase(phase: string): ParsedPhase {
+  if (phase === "lobby") return { kind: "lobby" };
+  if (phase === "ended") return { kind: "ended" };
+
+  const match = /^(round|revealing):(\d+)$/.exec(phase);
+  if (!match) throw new Error(`Unknown phase: ${phase}`);
+
+  const number = Number(match[2]);
+  if (number < 1 || number > MAX_ROUNDS) throw new Error(`Round ${number} is out of range`);
+
+  return { kind: match[1] as "round" | "revealing", number };
+}
+
+function roundState(phase: ParsedPhase, number: number): Doc<"rounds">["state"] {
+  if (phase.kind === "lobby") return "pending";
+  if (phase.kind === "ended") return "closed";
+  if (number > phase.number) return "closed";
+  if (number < phase.number) return "pending";
+  return phase.kind === "round" ? "open" : "revealing";
+}
+
+export type SeedPlayer = { name: string; avatar?: string; uid?: string };
+export type SeedSelection = { uid: string; roundNumber: number; pickName: string };
+
+export type SeededPlayer = { uid: string; name: string; isHost: boolean };
+export type SeededGame = {
+  sessionId: Id<"sessions">;
+  roundIds: Id<"rounds">[];
+  players: SeededPlayer[];
+};
+
+export type SeedGameArgs = {
+  topic?: string;
+  year?: number;
+  phase?: string;
+  players: SeedPlayer[];
+  selections?: SeedSelection[];
+};
+
+/** Handed out in order when a player brings no avatar of its own. */
+const AVATARS = ["🐙", "🦊", "🐝", "🦉", "🐢", "🦄", "🐳", "🦁", "🐸", "🦋"];
+
+type SeedCtx = Pick<MutationCtx, "db" | "scheduler">;
+
+/**
+ * A whole session at `phase`: the session row, its players (the first is the
+ * host), `MAX_ROUNDS` rounds in the states that phase implies, and any
+ * selections asked for. A `revealing` phase also schedules the reveal job
+ * `advanceRound` would have queued, so the round times out on its own.
+ */
+export async function seedSession(
+  ctx: SeedCtx,
+  { topic = Topic.GAMES, year = 2026, phase = "lobby", players, selections = [] }: SeedGameArgs,
+): Promise<SeededGame> {
+  const parsed = parsePhase(phase);
+
+  if (players.length === 0) throw new Error("A session needs at least one player");
+  if (players.length > MAX_PLAYERS) {
+    throw new Error(`A session holds at most ${MAX_PLAYERS} players`);
+  }
+
+  const status =
+    parsed.kind === "lobby"
+      ? SessionStatus.LOBBY
+      : parsed.kind === "ended"
+        ? SessionStatus.COMPLETE
+        : SessionStatus.ACTIVE;
+
+  // Rounds count down, so the lobby and a finished game both sit on round 1 —
+  // where `createSession` starts and where `completeRevealLogic` leaves it.
+  const activeRoundNumber =
+    parsed.kind === "round" || parsed.kind === "revealing" ? parsed.number : 1;
+
+  const sessionId = await ctx.db.insert("sessions", {
+    topic,
+    year,
+    maxRounds: MAX_ROUNDS,
+    maxPlayers: MAX_PLAYERS,
+    playerCount: players.length,
+    activeRoundNumber,
+    status,
+  });
+
+  const seededPlayers: SeededPlayer[] = [];
+
+  for (const [index, player] of players.entries()) {
+    const seeded = { uid: player.uid ?? testUid(), name: player.name, isHost: index === 0 };
+
+    await ctx.db.insert("players", {
+      sessionId,
+      uid: seeded.uid,
+      name: seeded.name,
+      avatar: player.avatar ?? AVATARS[index % AVATARS.length]!,
+      isHost: seeded.isHost,
+    });
+
+    seededPlayers.push(seeded);
+  }
+
+  const now = Date.now();
+
+  // One entry per round number, so a caller can bump `selectionsComplete` once
+  // per round rather than re-reading the row for every selection.
+  const completeByRound = new Map<number, number>();
+  for (const selection of selections) {
+    completeByRound.set(
+      selection.roundNumber,
+      (completeByRound.get(selection.roundNumber) ?? 0) + 1,
+    );
+  }
+
+  const roundIds: Id<"rounds">[] = [];
+
+  for (let number = 1; number <= MAX_ROUNDS; number++) {
+    const state = roundState(parsed, number);
+
+    roundIds.push(
+      await ctx.db.insert("rounds", {
+        sessionId,
+        number,
+        state,
+        weight: MAX_ROUNDS + 1 - number,
+        selectionsComplete: completeByRound.get(number) ?? 0,
+        startedAt: state === "pending" ? null : now,
+        closedAt: state === "closed" || state === "revealing" ? now : null,
+      }),
+    );
+  }
+
+  for (const { uid, roundNumber, pickName } of selections) {
+    const roundId = roundIds[roundNumber - 1];
+    if (!roundId) throw new Error(`Round ${roundNumber} is out of range`);
+
+    await ctx.db.insert("selections", {
+      sessionId,
+      roundId,
+      uid,
+      pick: { id: pickId(pickName), name: pickName },
+      points: MAX_ROUNDS + 1 - roundNumber,
+      roundNumber,
+      savedAt: now,
+    });
+  }
+
+  if (parsed.kind === "revealing") {
+    const roundId = roundIds[parsed.number - 1]!;
+    const durationMs = revealDurationMs(players.length);
+
+    const revealJobId = await ctx.scheduler.runAfter(durationMs, internal.rounds.completeReveal, {
+      sessionId,
+      roundNumber: parsed.number,
+    });
+
+    await ctx.db.patch(roundId, { revealJobId, revealEndsAt: Date.now() + durationMs });
+  }
+
+  return { sessionId, roundIds, players: seededPlayers };
+}

--- a/convex/test/seed.ts
+++ b/convex/test/seed.ts
@@ -4,6 +4,57 @@ import { v } from "convex/values";
 import { internalMutation } from "../_generated/server";
 import { MAX_ROUNDS } from "../constants";
 import { getRoundByNumber } from "../utils/rounds";
+import { pickId, seedSession, testUid } from "./phases";
+
+const playerArg = v.object({
+  name: v.string(),
+  avatar: v.optional(v.string()),
+  // Supply one to make a browser the player: an anonymous identity is minted by
+  // the deployment and signed with a key the suite never holds, so a uid the
+  // seed invented can never be adopted by a page. See `signInAs` in
+  // `playwright/helpers/convex.ts`.
+  uid: v.optional(v.string()),
+});
+
+const selectionArg = v.object({
+  uid: v.string(),
+  roundNumber: v.number(),
+  pickName: v.string(),
+});
+
+/** A LOBBY session with one named host — what `createSession` produces. */
+export const createSession = internalMutation({
+  args: {
+    topic: v.optional(v.string()),
+    year: v.optional(v.number()),
+    name: v.string(),
+    avatar: v.optional(v.string()),
+    hostUid: v.optional(v.string()),
+  },
+  handler: async (ctx, { topic, year, name, avatar, hostUid }) => {
+    const game = await seedSession(ctx, {
+      topic,
+      year,
+      phase: "lobby",
+      players: [{ name, avatar, uid: hostUid }],
+    });
+
+    return { sessionId: game.sessionId, hostUid: game.players[0]!.uid };
+  },
+});
+
+/** A session at any phase, with its players and their picks already in place. */
+export const seedGame = internalMutation({
+  args: {
+    topic: v.optional(v.string()),
+    year: v.optional(v.number()),
+    phase: v.string(),
+    players: v.array(playerArg),
+    selections: v.optional(v.array(selectionArg)),
+  },
+  handler: async (ctx, { topic, year, phase, players, selections }) =>
+    await seedSession(ctx, { topic, year, phase, players, selections }),
+});
 
 export const addPlayer = internalMutation({
   args: {
@@ -15,7 +66,7 @@ export const addPlayer = internalMutation({
     const session = await ctx.db.get(sessionId);
     if (!session) throw new Error("Session not found");
 
-    const uid = `test-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const uid = testUid();
 
     await ctx.db.insert("players", {
       sessionId,
@@ -49,7 +100,7 @@ export const makeSelection = internalMutation({
       roundId: round._id,
       uid,
       pick: {
-        id: pickName.toLowerCase().replace(/\s+/g, "-"),
+        id: pickId(pickName),
         name: pickName,
       },
       points: MAX_ROUNDS + 1 - roundNumber,

--- a/convex/utils/rounds.ts
+++ b/convex/utils/rounds.ts
@@ -9,6 +9,15 @@ export function isRoundRevealed(round: Doc<"rounds">) {
   return round.state === "revealing" || round.state === "closed";
 }
 
+/**
+ * How long a reveal runs before `completeReveal` closes the round — long enough
+ * for every player's pick to be shown in turn. Shared with the test seed so a
+ * seeded `revealing` round times out exactly like one `advanceRound` opened.
+ */
+export function revealDurationMs(playerCount: number) {
+  return playerCount * 4_000 + 5_000;
+}
+
 export async function getRoundByNumber(
   db: DatabaseReader,
   sessionId: Id<"sessions">,

--- a/playwright/game/seed.e2e.ts
+++ b/playwright/game/seed.e2e.ts
@@ -1,0 +1,90 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { seedGame, seedLobby, signIn } from "../helpers/convex";
+
+const YEAR = 2026;
+
+/** Where a seeded session lives, given the topic and year it was seeded with. */
+function sessionUrl(sessionId: string) {
+  return `/games/${YEAR}/${sessionId}`;
+}
+
+/**
+ * The page signs itself in, so the seed can hand it the identity it already
+ * has — see `currentUid` in `playwright/helpers/convex.ts` for why it goes in
+ * that direction and not the other.
+ */
+async function hostFor(page: Page, name: string) {
+  return { name, uid: await signIn(page) };
+}
+
+test("seed: a lobby the host lands in without filling the setup form", async ({ page }) => {
+  const uid = await signIn(page);
+  const { sessionId, hostUid } = await seedLobby({ name: "Host", year: YEAR, hostUid: uid });
+
+  expect(hostUid).toBe(uid);
+
+  await page.goto(sessionUrl(sessionId));
+
+  await expect(page.getByTestId("lobby-start")).toBeVisible();
+  await expect(page.getByTestId("name-input")).toHaveCount(0);
+  await expect(page.getByTestId("player-count")).toHaveText("1 of 10");
+});
+
+test("seed: a round in play, without walking the rounds before it", async ({ page }) => {
+  const host = await hostFor(page, "Host");
+  const { sessionId } = await seedGame({
+    phase: "round:8",
+    year: YEAR,
+    players: [host, { name: "Guest" }],
+  });
+
+  await page.goto(sessionUrl(sessionId));
+
+  await expect(page.getByText("Round 8")).toBeVisible();
+  await expect(page.getByTestId("pick-input")).toBeVisible();
+});
+
+test("seed: a reveal already running, with the picks it reveals", async ({ page }) => {
+  const host = await hostFor(page, "Host");
+  const guestUid = "seeded-guest";
+
+  const { sessionId } = await seedGame({
+    phase: "revealing:10",
+    year: YEAR,
+    players: [host, { name: "Guest", uid: guestUid }],
+    selections: [
+      { uid: host.uid, roundNumber: 10, pickName: "Blue Prince" },
+      { uid: guestUid, roundNumber: 10, pickName: "Balatro" },
+    ],
+  });
+
+  await page.goto(sessionUrl(sessionId));
+
+  await expect(page.getByTestId("reveal-container")).toBeVisible();
+  await expect(page.getByTestId("reveal-countdown")).toBeVisible();
+  // The host drives the reveal, so the skip button is the host-only proof that
+  // the seeded uid really is the identity this page holds.
+  await expect(page.getByTestId("reveal-skip")).toBeVisible();
+});
+
+test("seed: results without playing ten rounds to reach them", async ({ page }) => {
+  const host = await hostFor(page, "Host");
+
+  const { sessionId } = await seedGame({
+    phase: "ended",
+    year: YEAR,
+    players: [host, { name: "Guest", uid: "seeded-guest" }],
+    selections: [
+      { uid: host.uid, roundNumber: 10, pickName: "Blue Prince" },
+      { uid: host.uid, roundNumber: 9, pickName: "Balatro" },
+    ],
+  });
+
+  await page.goto(sessionUrl(sessionId));
+
+  await expect(page.getByTestId("results-list")).toBeVisible();
+  await expect(page.getByText("Blue Prince")).toBeVisible();
+  await expect(page.getByText("Balatro")).toBeVisible();
+  await expect(page.getByTestId("pick-input")).toHaveCount(0);
+});

--- a/playwright/helpers/convex.ts
+++ b/playwright/helpers/convex.ts
@@ -1,3 +1,5 @@
+import type { Page } from "@playwright/test";
+
 const siteUrl = process.env.CONVEX_SITE_URL ?? "";
 const testSecret = process.env.TEST_SECRET ?? "";
 
@@ -17,6 +19,101 @@ export async function cleanup() {
     headers: HEADERS,
   });
   if (!res.ok) await failWithBody("Cleanup failed", res);
+}
+
+async function post<T>(path: string, label: string, body: unknown): Promise<T> {
+  const res = await fetch(`${siteUrl}${path}`, {
+    method: "POST",
+    headers: HEADERS,
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) await failWithBody(label, res);
+  return (await res.json()) as T;
+}
+
+/**
+ * The uid the page is signed in as, once the app has minted its anonymous
+ * identity. Convex Auth keeps the token in `localStorage` under a key
+ * namespaced by the deployment URL, and its `sub` claim is the `uid` every
+ * server function reads off `getUserIdentity()`.
+ *
+ * There is no `signInAs(page, uid)`, and there cannot be: the token is signed
+ * with the deployment's key, which the suite never holds, so a page can never
+ * adopt a uid the seed invented. The traffic runs the other way — let the page
+ * sign itself in, read the uid here, and hand it to `seedLobby`/`seedGame` as a
+ * player. Only a seeded player that never drives a browser gets a server uid.
+ */
+export async function currentUid(page: Page): Promise<string> {
+  const handle = await page.waitForFunction(() => {
+    const key = Object.keys(localStorage).find((name) => name.startsWith("__convexAuthJWT"));
+    const token = key ? localStorage.getItem(key) : null;
+    const payload = token?.split(".")[1];
+    if (!payload) return null;
+
+    const claims = JSON.parse(atob(payload.replace(/-/g, "+").replace(/_/g, "/")));
+    return typeof claims.sub === "string" ? claims.sub : null;
+  });
+
+  return await handle.jsonValue();
+}
+
+/**
+ * Signs the page in anonymously and returns its uid. Any route under `/$topic`
+ * will do — that layout is where `useAnonymousAuth` is mounted, so home on its
+ * own never mints an identity.
+ */
+export async function signIn(page: Page, path = "/games/2026"): Promise<string> {
+  await page.goto(path);
+  return await currentUid(page);
+}
+
+export type SeedPlayer = { name: string; avatar?: string; uid?: string };
+export type SeedSelection = { uid: string; roundNumber: number; pickName: string };
+export type SeededPlayer = { uid: string; name: string; isHost: boolean };
+
+/** A lobby with one named host, skipping home → start → name → submit. */
+export async function seedLobby({
+  name,
+  topic,
+  year,
+  hostUid,
+}: {
+  name: string;
+  topic?: string;
+  year?: number;
+  hostUid?: string;
+}) {
+  return await post<{ sessionId: string; hostUid: string }>(
+    "/test/create-session",
+    "Create session failed",
+    { name, topic, year, hostUid },
+  );
+}
+
+/**
+ * A session already at `phase` — `lobby`, `round:<n>`, `revealing:<n>` or
+ * `ended`. The first player is the host; pass a `uid` from `signIn` for
+ * whichever player drives the browser. Rounds count down, so a game starts at
+ * `round:10` and ends at `round:1`.
+ */
+export async function seedGame({
+  phase,
+  players,
+  selections,
+  topic,
+  year,
+}: {
+  phase: string;
+  players: SeedPlayer[];
+  selections?: SeedSelection[];
+  topic?: string;
+  year?: number;
+}) {
+  return await post<{ sessionId: string; roundIds: string[]; players: SeededPlayer[] }>(
+    "/test/seed-game",
+    "Seed game failed",
+    { phase, players, selections, topic, year },
+  );
 }
 
 export async function addPlayer({


### PR DESCRIPTION
Closes #166

## Summary

Every spec built its session through the UI first — home, start, name, submit — and the results spec walked ten rounds just to reach the screen it was named for. This adds a server-side way to seed a session already at a given phase (`lobby`, `round:<n>`, `revealing:<n>`, `ended`), shared by unit tests and e2e specs, so a spec can ask for the state it actually wants to test instead of driving through every state before it.

## Changes

- `convex/test/phases.ts` (new): one definition of what a phase is — the session, players, rounds, and any selections it implies — used by both the unit-test harness and the new `/test/seed-game` route.
- `convex/test/seed.ts`, `convex/test/http.ts`, `convex/http.ts`: two new test-only HTTP routes, `/test/create-session` and `/test/seed-game`, gated the same way as the existing `/test/*` routes. `test/http.ts` route bodies collapsed onto one `testRoute` helper instead of repeating the guard/JSON boilerplate per route.
- `convex/__tests__/harness.setup.ts`: `seedActiveGame`/`seedLobbyGame`/`seedFinalRound`/`seedCompleteGame` now all call `seedSession` from `test/phases.ts` instead of hand-rolling rows, and `setupTest` takes a `freshHttp` option to re-evaluate `convex/http.ts` under a distinct module specifier (needed to test the `TEST_SECRET`/`IS_PROD` guard itself, since bun otherwise caches the module).
- `convex/__tests__/test-routes.test.ts` (new): coverage for both new routes — auth rejection, each phase's shape, the scheduled reveal job on a `revealing` phase, and that none of the `/test/*` routes register when `IS_PROD` is set.
- `convex/utils/rounds.ts`, `convex/rounds.ts`, `convex/selections.ts`: pulled the reveal-duration formula (`playerCount * 4_000 + 5_000`) into `revealDurationMs()` so the seed can't drift from it; `advanceRound` and `saveSelection`'s all-picked branch now both call it.
- `playwright/helpers/convex.ts`: `signIn`/`currentUid` to read the uid a page mints for itself, and `seedLobby`/`seedGame` wrapping the two new routes.
- `playwright/game/seed.e2e.ts` (new): four specs — a lobby, a round in play, a reveal in progress, and results — each reached by seeding instead of playing through prior rounds.
- `convex/_generated/api.d.ts`: two lines for the new `test/phases` module.

## Verification

Per `gate.log`: `bun test --coverage` (127 pass, 0 fail), `bunx tsc --noEmit`, `bunx oxlint .` (0 warnings/errors), `bunx oxfmt --check .` all passed. `mise run test:e2e` also ran and passed in full — 33/33, including the four new `playwright/game/seed.e2e.ts` specs. The implement commit's notes say e2e wasn't run because no `CONVEX_DEPLOY_KEY` was reachable from that worktree; the gate environment had one, so that's now verified rather than outstanding.

## Notes for reviewer

- `convex/_generated/api.d.ts` is hand-edited, not regenerated by `convex codegen` — no deployment was reachable to run it. It's two mechanical lines in codegen's existing alphabetical shape, and the e2e run above (which deploys for real) exercising `test/phases` is what shows it's right.
- There is deliberately no `signInAs(page, uid)`. An anonymous identity's token is signed by the deployment, which the test suite never holds, so a page can't be made to adopt a uid the seed invented. The traffic runs the other way: `signIn(page)` mints the identity first, and that uid is handed to `seedGame` as a player. See the comment on `currentUid` in `playwright/helpers/convex.ts`.
- Rounds count down, so `round:<n>` is round number `n` directly — a game starts at `round:10` and ends at `round:1`. Worth double-checking against `activeRoundNumber` if anything here looks backwards at a glance.
- `setupTest({ freshHttp: true })` is a small workaround for bun's module cache (needed only by the new guard test in `test-routes.test.ts`); every other existing test is unaffected and still calls `setupTest()` with no args.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
