### PR TITLE
test(e2e): tag the journey specs @smoke and name the subset

### DIFF
--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -43,6 +43,15 @@ new deployment's URL, and serves that build. It takes no deployment settings
 from `.env.local`; everything the suite talks to is created by the run and
 passed to Playwright as environment for that one command.
 
+`mise run test:e2e:smoke` runs the same thing over the three journey specs
+only — `pregame/smoke`, `game/single-player`, `game/multiplayer`, the ones
+tagged `@smoke`. That is the subset for the loop while working; before a PR run
+the whole suite, and CI runs everything regardless. It is a task rather than
+something you remember because the tag is ours, not Playwright's, and `mise
+tasks` is where this repo says what there is to run. Arguments reach Playwright
+either way, so any other slice is a flag: `mise run test:e2e -- --grep @smoke`
+is exactly what the task runs, and `-- --ui` or `-- --retries 0` work the same.
+
 The one thing it needs is `CONVEX_DEPLOY_KEY`, a preview deploy key from the
 Convex dashboard. Keep it in `.env.local`: bun loads that file automatically, so
 a checkout needs no exporting and no shell setup. The script fails immediately

--- a/mise.toml
+++ b/mise.toml
@@ -52,6 +52,10 @@ run = "bun test --coverage"
 description = "Playwright against a Convex preview deployment this run creates"
 run = "bun scripts/e2e.ts"
 
+[tasks."test:e2e:smoke"]
+description = "The three journey specs only — the fast subset for the working loop"
+run = "bun scripts/e2e.ts --grep @smoke"
+
 [tasks.check]
 description = "Format, lint, types and unit tests — what must pass before a commit"
 depends = ["format", "lint", "types", "test"]

--- a/playwright/game/multiplayer.e2e.ts
+++ b/playwright/game/multiplayer.e2e.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 
 import { addPlayer, makeSelection } from "../helpers/convex";
 
-test("multiplayer: host flow with advance-round", async ({ page }) => {
+test("multiplayer: host flow with advance-round", { tag: "@smoke" }, async ({ page }) => {
   await page.goto("/");
 
   // Home → Setup

--- a/playwright/game/single-player.e2e.ts
+++ b/playwright/game/single-player.e2e.ts
@@ -10,7 +10,7 @@ async function pickRound(page: Page, letter: string) {
   await page.getByTestId("reveal-skip").click();
 }
 
-test("single-player: full game", async ({ page }) => {
+test("single-player: full game", { tag: "@smoke" }, async ({ page }) => {
   await page.goto("/");
 
   // Home → Setup

--- a/playwright/pregame/smoke.e2e.ts
+++ b/playwright/pregame/smoke.e2e.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-test("smoke: home → setup → lobby → round → settings", async ({ page }) => {
+test("smoke: home → setup → lobby → round → settings", { tag: "@smoke" }, async ({ page }) => {
   await page.goto("/");
 
   // Home Screen


### PR DESCRIPTION
Closes #206

## Summary

There was no fast subset of the e2e suite — the whole thing ran or nothing did, which made it a pre-PR ritual rather than something you run while working. This tags the three journey specs `@smoke` and gives the subset a name.

## Changes

- `{ tag: "@smoke" }` on `pregame/smoke`, `game/single-player` and `game/multiplayer`.
- `[tasks."test:e2e:smoke"]` in `mise.toml`, running `bun scripts/e2e.ts --grep @smoke`.
- `docs/local-dev.md`: the task, why it's a task rather than only the flag, and `mise run test:e2e -- --grep @smoke` as the equivalent.
- `test:e2e` and `ci` unchanged — CI still runs everything.

## Verification

- `mise run check` passes.
- `bunx playwright test --grep @smoke --list` selects exactly the three journey specs and nothing else.
- The subset was not run end-to-end here: it needs a `CONVEX_DEPLOY_KEY` the pipeline worktree does not have.

## Notes for reviewer

- The ticket originally carried an acceptance criterion that the subset finish in under 60s locally, provisioning included, with the number posted on the issue. That was removed from #206 before this PR: the pipeline can't measure it, and a wall-clock gate on a run that includes `convex deploy` plus `vite build` isn't a criterion worth blocking on. Selection correctness is what's asserted instead.
- Task over flag-only was a judgement call: the tag is ours, not Playwright's, so nothing outside the spec files would advertise that a fast subset exists, and `mise tasks` is where this repo states what there is to run. The flag form still works for any other slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
