### PR TITLE
test(e2e): drive the three untested realtime transitions from a second browser

### DIFF
--- a/playwright/game/multiplayer.e2e.ts
+++ b/playwright/game/multiplayer.e2e.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "@playwright/test";
 
-import { addPlayer, makeSelection } from "../helpers/convex";
+import { addPlayer, makeSelection, seedGame, signIn } from "../helpers/convex";
+
+const YEAR = 2026;
 
 test("multiplayer: host flow with advance-round", { tag: "@smoke" }, async ({ page }) => {
   await page.goto("/");
@@ -116,4 +118,53 @@ test("multiplayer: host flow with advance-round", { tag: "@smoke" }, async ({ pa
   await expect(page.getByText("Mario")).toBeVisible();
   await expect(page.getByText("Hades")).toBeVisible();
   await expect(page.getByText(/\d+pts/).first()).toBeVisible();
+});
+
+test("multiplayer: a guest's pick reaches the host's player list", async ({ browser }) => {
+  const hostContext = await browser.newContext();
+  const hostPage = await hostContext.newPage();
+  const guestContext = await browser.newContext();
+  const guestPage = await guestContext.newPage();
+
+  // Each page signs itself in before the seed runs — a page can only be handed
+  // an identity it already holds, see `currentUid` in helpers/convex.ts.
+  const hostUid = await signIn(hostPage);
+  const guestUid = await signIn(guestPage);
+
+  const { sessionId } = await seedGame({
+    phase: "round:10",
+    year: YEAR,
+    players: [
+      { name: "Ryan", uid: hostUid },
+      { name: "Melissa", uid: guestUid },
+    ],
+  });
+
+  await hostPage.goto(`/games/${YEAR}/${sessionId}`);
+  await guestPage.goto(`/games/${YEAR}/${sessionId}`);
+  await expect(guestPage.getByTestId("pick-input")).toBeVisible();
+
+  // The host watches the list while the round is still open — with two players
+  // and only one pick in, nothing closes the round.
+  await hostPage.getByTestId("settings-button").click();
+  await expect(hostPage.getByTestId("sidebar-title")).toBeVisible();
+
+  const guestRow = hostPage.getByText("Melissa").locator("..");
+  const hostRow = hostPage.getByText("Ryan").locator("..");
+  await expect(guestRow).toContainText("...");
+
+  // Guest picks in their own browser
+  await guestPage.getByTestId("pick-input").fill("a");
+  await expect(guestPage.getByTestId("suggestion-item").first()).toBeVisible();
+  await guestPage.getByTestId("suggestion-item").first().click();
+  await expect(guestPage.getByTestId("submit-pick")).toBeEnabled();
+  await guestPage.getByTestId("submit-pick").click();
+
+  // Host's list marks the guest done and leaves the host, who has not picked,
+  // as they were
+  await expect(guestRow).toContainText("✓");
+  await expect(hostRow).toContainText("...");
+
+  await hostContext.close();
+  await guestContext.close();
 });

--- a/playwright/game/non-host.e2e.ts
+++ b/playwright/game/non-host.e2e.ts
@@ -1,5 +1,9 @@
 import { expect, test, type Page } from "@playwright/test";
 
+import { seedGame, signIn } from "../helpers/convex";
+
+const YEAR = 2026;
+
 async function pickRound(page: Page, letter: string) {
   await page.getByTestId("pick-input").fill(letter);
   await expect(page.getByTestId("suggestion-item").first()).toBeVisible();
@@ -164,6 +168,47 @@ test("non-host: host leaving game shows toast and redirects to home", async ({ b
   await expect(guestPage.getByTestId("toast")).toBeVisible();
   await expect(guestPage.getByTestId("toast")).toHaveText("The host forfeited the game.");
   await expect(guestPage.getByTestId("home-start")).toBeVisible();
+
+  await hostContext.close();
+  await guestContext.close();
+});
+
+test("non-host: host advancing mid-game moves the guest's round", async ({ browser }) => {
+  const hostContext = await browser.newContext();
+  const hostPage = await hostContext.newPage();
+  const guestContext = await browser.newContext();
+  const guestPage = await guestContext.newPage();
+
+  // Each page signs itself in before the seed runs — a page can only be handed
+  // an identity it already holds, see `currentUid` in helpers/convex.ts.
+  const hostUid = await signIn(hostPage);
+  const guestUid = await signIn(guestPage);
+
+  const { sessionId } = await seedGame({
+    phase: "round:8",
+    year: YEAR,
+    players: [
+      { name: "Ryan", uid: hostUid },
+      { name: "Melissa", uid: guestUid },
+    ],
+  });
+
+  await hostPage.goto(`/games/${YEAR}/${sessionId}`);
+  await guestPage.goto(`/games/${YEAR}/${sessionId}`);
+
+  // Both are on round 8 before the advance, so what follows is the advance
+  // reaching a live guest page rather than a page loading after the fact.
+  await expect(hostPage.getByText("Round 8")).toBeVisible();
+  await expect(guestPage.getByText("Round 8")).toBeVisible();
+
+  // Host advances from the sidebar. Nobody has picked, so the round advances
+  // directly — no reveal to skip.
+  await hostPage.getByTestId("settings-button").click();
+  await expect(hostPage.getByTestId("advance-round")).toBeVisible();
+  await hostPage.getByTestId("advance-round").click();
+
+  await expect(guestPage.getByText("Round 7")).toBeVisible();
+  await expect(hostPage.getByText("Round 7")).toBeVisible();
 
   await hostContext.close();
   await guestContext.close();

--- a/playwright/game/sidebar.e2e.ts
+++ b/playwright/game/sidebar.e2e.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "@playwright/test";
 
-import { addPlayer } from "../helpers/convex";
+import { addPlayer, seedGame, signIn } from "../helpers/convex";
+
+const YEAR = 2026;
 
 test("sidebar: opens and closes via button and backdrop", async ({ page }) => {
   await page.goto("/");
@@ -77,4 +79,50 @@ test("kick: host kicks a player from the game sidebar", async ({ page }) => {
   // Close sidebar
   await page.getByTestId("close-sidebar").click();
   await expect(page.getByTestId("sidebar-title")).not.toBeVisible();
+});
+
+test("kick: the kicked player's own screen reacts", async ({ browser }) => {
+  const hostContext = await browser.newContext();
+  const hostPage = await hostContext.newPage();
+  const guestContext = await browser.newContext();
+  const guestPage = await guestContext.newPage();
+
+  // Each page signs itself in before the seed runs — a page can only be handed
+  // an identity it already holds, see `currentUid` in helpers/convex.ts.
+  const hostUid = await signIn(hostPage);
+  const guestUid = await signIn(guestPage);
+
+  const { sessionId } = await seedGame({
+    phase: "round:10",
+    year: YEAR,
+    players: [
+      { name: "Ryan", uid: hostUid },
+      { name: "Melissa", uid: guestUid },
+    ],
+  });
+
+  await hostPage.goto(`/games/${YEAR}/${sessionId}`);
+  await guestPage.goto(`/games/${YEAR}/${sessionId}`);
+
+  // The guest is subscribed before the kick lands, so what follows is the kick
+  // reaching a live page rather than a page loading after the fact.
+  await expect(guestPage.getByText("Round 10")).toBeVisible();
+
+  await hostPage.getByTestId("settings-button").click();
+  await expect(hostPage.getByTestId("sidebar-title")).toBeVisible();
+  await expect(hostPage.getByText("Melissa")).toBeVisible();
+
+  await hostPage.getByText("Melissa").locator("..").getByTestId("kick-player").click();
+
+  // The kicked player's live queries throw NOT_MEMBER, which the root
+  // ErrorBoundary turns into the error state with a way home.
+  await expect(guestPage.getByTestId("error-state")).toBeVisible();
+  await expect(guestPage.getByText("Player not in session")).toBeVisible();
+  await expect(guestPage.getByTestId("error-home")).toBeVisible();
+
+  // And the host's list drops them.
+  await expect(hostPage.getByText("Melissa")).not.toBeVisible();
+
+  await hostContext.close();
+  await guestContext.close();
 });


### PR DESCRIPTION
Closes #167

## Summary

Three realtime transitions changed state through an API call, so nothing proved the *other* player's screen actually reacted. Each now gets a second, real browser page driving the change and a first page asserting the effect, added to the spec that already covers the feature rather than a new `playwright/realtime/` directory.

## Changes

- `playwright/game/sidebar.e2e.ts`: the host kicks a real guest page; the guest's live queries throw `NOT_MEMBER` and it lands on the error state with a home link.
- `playwright/game/multiplayer.e2e.ts`: a guest submits a pick in their own browser; the host's player list flips that guest to done while the round is still open.
- `playwright/game/non-host.e2e.ts`: the host advances mid-game; the guest's round moves 8 → 7.

## Verification

Per `gate.log`: `bun test --coverage` (127 pass, 0 fail), `oxfmt --check`, `tsc --noEmit`, and `oxlint` all passed. `mise run test:e2e` then ran the full Playwright suite against a preview deployment — 36 passed, including the three new specs (`sidebar.e2e.ts:84`, `multiplayer.e2e.ts:123`, `non-host.e2e.ts:176`). Not run: the ticket's ask for green 5x with `--retries 0` — the suite ran once.

## Notes for reviewer

- Setup uses #166's seeding: each page signs itself in, and the seed is handed the uid it already holds. The existing specs are untouched — the existing API-driven kick and selection tests still stand as they were.
- There is no numeric "submitted" counter anywhere in the UI. The only surface for a guest's pick reaching the host is the per-player check mark in the sidebar player list, so that's what the pick test asserts.
- `src/screens/settings.tsx` (route `/$topic/$year/$sessionId/settings`) is a near-duplicate of `components/sidebar/sidebar-content.tsx` — same kick, advance and leave handlers — and the game header opens the sidebar, not that route. Nothing drives it in e2e. Flagging, not touching.
- No new dependencies, no `.github/**` or `.claude/**` changes, no regenerated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
