### PR TITLE
build(deps): move the bun pin to 1.4.2

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -4,7 +4,7 @@
 # The project runtime and package manager. Keep in step with `engines.bun` in
 # package.json and with the version CI installs (`.github/workflows/ci.yml`
 # reads this file).
-bun = "1.3.11"
+bun = "1.4.2"
 
 # Playwright only. Its test runner (1.62) will not load our specs under the bun
 # runtime — `bunx playwright test` with no node on PATH fails with


### PR DESCRIPTION
Closes #211

## Summary

Bumps the bun pin in `mise.toml` from `1.3.11` to `1.4.2`, current at time of writing. CI installs from this file, so the pin is what keeps local and CI resolving identically.

## Changes

- `mise.toml`: bump `bun` from `1.3.11` to `1.4.2`.

## Verification

Ran `mise run check` (format, lint, types, unit) and `mise run test:e2e`, both green:

- `bun test --coverage`: 127 pass, 0 fail, coverage floor (87% functions / 89% lines) passes at 89.30%/91.01%.
- `bunx oxfmt --check .`: clean.
- `bunx tsc --noEmit`: clean.
- `bunx oxlint .`: 0 warnings, 0 errors.
- `mise run test:e2e`: 36/36 Playwright specs passed against a preview Convex deployment.

`bun install` under 1.4.2 rewrote nothing — `bun.lock` is byte-identical and `bun install --frozen-lockfile` is clean, so there's no lockfile diff in this PR.

## Notes for reviewer

- Single-line change, low risk. The only real question was whether bun 1.4's lockfile format change (adds SHA-512 integrity to `github:`/tarball deps) would touch `bun.lock` — it doesn't, since this repo has none of those.
- `engines.bun` in `package.json` (`>=1.3.6`) still reads true and was left alone, along with the `mise.toml` comment that points at it.
- Node stays pinned bare `24` per #164 (Playwright's runner needs a node on PATH) — out of scope here and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
