### PR TITLE
docs(contributing): how to write a ticket, and stop hard-wrapping bodies

### DIFF
--- a/.github/ISSUE_TEMPLATE/ticket.yml
+++ b/.github/ISSUE_TEMPLATE/ticket.yml
@@ -5,7 +5,7 @@ body:
     id: summary
     attributes:
       label: Summary
-      description: What and why, in a paragraph. Link the source (bug report, tweet, PR comment) if there is one. One paragraph per line, however long — GitHub renders every newline as a line break, so do not hard-wrap.
+      description: What and why, in a paragraph. Link the source (bug report, tweet, PR comment) if there is one.
     validations:
       required: true
   - type: textarea
@@ -19,7 +19,7 @@ body:
     id: acceptance
     attributes:
       label: Acceptance
-      description: "How we know it is done, as Given / When / Then — one per behaviour, each observable by someone who did not write it. Checks that must pass and tests that must exist go here too, as their own bullets. See docs/contributing.md."
+      description: "How we know it is done, as Given / When / Then — one per behaviour, each observable by someone who did not write it. Checks that must pass and tests that must exist go here too, as their own bullets."
       placeholder: |
         - Given a lobby with two guests
           When the host leaves
@@ -31,4 +31,4 @@ body:
     id: out-of-scope
     attributes:
       label: Out of scope
-      description: Adjacent things this ticket deliberately does not touch.
+      description: Adjacent things this ticket deliberately does not touch, and why, so the next reader does not reopen the decision.

--- a/.github/ISSUE_TEMPLATE/ticket.yml
+++ b/.github/ISSUE_TEMPLATE/ticket.yml
@@ -5,7 +5,7 @@ body:
     id: summary
     attributes:
       label: Summary
-      description: What and why, in a paragraph. Link the source (bug report, tweet, PR comment) if there is one.
+      description: What and why, in a paragraph. Link the source (bug report, tweet, PR comment) if there is one. One paragraph per line, however long — GitHub renders every newline as a line break, so do not hard-wrap.
     validations:
       required: true
   - type: textarea
@@ -19,7 +19,12 @@ body:
     id: acceptance
     attributes:
       label: Acceptance
-      description: How we know it is done — behaviour to observe, checks that must pass, tests that must exist.
+      description: "How we know it is done, as Given / When / Then — one per behaviour, each observable by someone who did not write it. Checks that must pass and tests that must exist go here too, as their own bullets. See docs/contributing.md."
+      placeholder: |
+        - Given a lobby with two guests
+          When the host leaves
+          Then the lobby closes and both guests see the closed toast
+        - `bun run checks` passes
     validations:
       required: true
   - type: textarea

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Detailed rules live in `.claude/rules/` and load when you touch matching files. 
 
 Docs, read when relevant:
 
-- `docs/contributing.md`: branches, commits, PR process, what to disclose.
+- `docs/contributing.md`: branches, commits, PR process, what to disclose, and how to write a ticket or PR body — including that nothing is hard-wrapped, because GitHub renders every newline as a line break.
 - `docs/local-dev.md`: checks, e2e, the shared dev deployment, generated files.
 - `docs/release.md`: how releases are cut.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -47,6 +47,30 @@ Only `feat` and `fix` change a version, and only the types listed in
 `changelog-sections` appear in the changelog — everything else rides along
 silently. So the type is for the reader, not for the release; see `release.md`.
 
+## Tickets
+
+`.github/ISSUE_TEMPLATE/ticket.yml`: Summary, Change, Acceptance, Out of scope. Summary is what is wrong and why it matters. Change is what is different when this is done, concrete enough that a diff can be checked against it. Out of scope is where a decision goes so the next reader does not reopen it.
+
+Acceptance is **Given / When / Then**, one per behaviour, each observable by someone who did not write it:
+
+    - Given a lobby with two guests
+      When the host leaves
+      Then the lobby closes and both guests see the closed toast
+    - `bun run checks` passes
+
+Given the starting state, When the thing happens, Then what must be true. Checks that must pass and tests that must exist are their own bullets. A restatement of Change is not acceptance — if the Then is "the code does what Change said", there is nothing to observe and nothing to disagree with.
+
+An investigation ticket has a Change and an Acceptance like any other. The Change is the work of investigating; the Acceptance is the recommendation and the evidence that justifies it. "Keep what we have" is a legitimate outcome and is named as one.
+
+## Writing it
+
+Applies to tickets, PR bodies, and comments on either.
+
+- **Do not hard-wrap.** One paragraph or one bullet per line, however long. GitHub renders every newline in an issue or PR body as a line break, so a body wrapped at 80 columns renders as ragged fixed-width text. This is the rule most often broken, because most editors wrap by default.
+- **GitHub-flavoured markdown.** Tables, task lists and fenced code render. Nested bullets indent two spaces; nothing else indents.
+- **Be terse in a Summary.** What is wrong, what will be different, stop. The reasoning belongs in the section it is about.
+- **Reference, do not restate.** A rule copied into a second place drifts from the first. Point at the file that states it.
+
 ## Before asking for review
 
 - Rebase onto the PR's base. `git log --oneline <base>..HEAD` must show only


### PR DESCRIPTION
Refs #180

## Summary

`contributing.md` covered branches, commits, the PR process and what to disclose, but never what a ticket looks like or how any of it should be written. The ticket template named its four fields and left "how we know it is done" open enough that acceptance was often a restatement of the change — which is nothing anyone can observe or disagree with. Separately, GitHub renders every newline in an issue or PR body as a line break, so a body wrapped at 80 columns renders as ragged fixed-width text; nothing said so anywhere, most editors wrap by default, and it kept happening.

## Changes

- `docs/contributing.md`: new **Tickets** section — the four fields, what each is for, and Acceptance as Given / When / Then, one per behaviour, each observable by someone who did not write it, with checks and tests as their own bullets. Says explicitly that a restatement of Change is not acceptance, and that an investigation ticket still has a Change and an Acceptance (the Change is the investigating, the Acceptance is the recommendation and its evidence).
- `docs/contributing.md`: new **Writing it** section — no hard-wrapping and why, GitHub-flavoured markdown, terse summaries, and reference rather than restate.
- `.github/ISSUE_TEMPLATE/ticket.yml`: Acceptance gains the Given / When / Then description and a placeholder showing the shape. Out of scope gains why, so a decision recorded there is not reopened. The descriptions say what to write, not how to render it, and none of them names a path — `CLAUDE.md` already says where this repo's rules are, and a template that repeats it is a second place to keep in step. Field descriptions are now identical to the pipeline repo's; only the placeholders differ, being examples from their own repo.
- `CLAUDE.md`: the one-line pointer at `docs/contributing.md` now names what it covers, including the newline rule.

## Verification

`ticket.yml` parses as YAML and still yields the four fields — Summary, Change, Acceptance, Out of scope. Docs and template data only; no application code changed, so the checks and e2e suite are unaffected.

Not verified: how the new placeholder renders in GitHub's issue form UI. That is only observable once the template is on `main`, so it is worth a look at the first ticket opened after this merges.

## Notes for reviewer

- Given / When / Then is a real change of convention rather than a write-up of what was already happening, so it is the thing to push back on if you disagree. The argument for it is that the old Acceptance wording allowed a restatement of Change, and a restatement gives a reviewer nothing to check.
- The same ticket shape is landing in the pipeline repo (30somethinggames/pipeline#29), so the two repos state one shape rather than two versions of it. That PR keeps the rules in `.claude/rules/writing.md` because that repo has no `docs/`; this one extends `contributing.md` because it already exists and a second file would be the duplication both PRs are trying to remove.
- A change under `.github/**`: `ISSUE_TEMPLATE/ticket.yml`, template data only, no workflow or permission change.
- No new dependencies, no regenerated files, no test changed.
